### PR TITLE
feat: implement x402 protocol dual-mode payment (Points + USDC on Base Sepolia)

### DIFF
--- a/drizzle/migrations/0003_x402_protocol.sql
+++ b/drizzle/migrations/0003_x402_protocol.sql
@@ -1,0 +1,24 @@
+-- x402 protocol: add payment_mode and escrow_tx_hash to tasks
+ALTER TABLE "tasks" ADD COLUMN "payment_mode" varchar(10) NOT NULL DEFAULT 'points';
+ALTER TABLE "tasks" ADD COLUMN "escrow_tx_hash" varchar(128);
+
+-- x402 protocol: add evm_address to agents
+ALTER TABLE "agents" ADD COLUMN "evm_address" varchar(42);
+
+-- x402 payments tracking table
+CREATE TABLE "x402_payments" (
+	"id" bigserial PRIMARY KEY NOT NULL,
+	"task_id" varchar(12),
+	"payer_address" varchar(42) NOT NULL,
+	"recipient_address" varchar(42) NOT NULL,
+	"amount_usdc" numeric(12, 6) NOT NULL,
+	"tx_hash" varchar(128) NOT NULL,
+	"network" varchar(20) NOT NULL,
+	"payment_type" varchar(20) NOT NULL,
+	"created_at" timestamptz DEFAULT now(),
+	CONSTRAINT "x402_payments_tx_hash_unique" UNIQUE("tx_hash")
+);
+
+ALTER TABLE "x402_payments" ADD CONSTRAINT "x402_payments_task_id_tasks_id_fk" FOREIGN KEY ("task_id") REFERENCES "public"."tasks"("id") ON DELETE no action ON UPDATE no action;
+CREATE INDEX "idx_x402_payments_task" ON "x402_payments" USING btree ("task_id");
+CREATE INDEX "idx_x402_payments_payer" ON "x402_payments" USING btree ("payer_address");

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -23,5 +23,12 @@
       "tag": "0002_a2a_task_contexts",
       "breakpoints": true
     }
+    ,{
+      "idx": 3,
+      "version": "7",
+      "when": 1773600000000,
+      "tag": "0003_x402_protocol",
+      "breakpoints": true
+    }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,16 @@
       "version": "1.0.0",
       "dependencies": {
         "@hono/node-server": "^1.13.7",
+        "@x402/core": "^2.6.0",
+        "@x402/evm": "^2.6.0",
+        "@x402/hono": "^2.6.0",
         "bcrypt": "^5.1.1",
         "dotenv": "^16.4.7",
         "drizzle-orm": "^0.39.3",
         "hono": "^4.7.4",
         "jose": "^6.2.1",
-        "pg": "^8.13.3"
+        "pg": "^8.13.3",
+        "viem": "^2.47.2"
       },
       "devDependencies": {
         "@types/bcrypt": "^5.0.2",
@@ -24,6 +28,13 @@
         "tsx": "^4.19.3",
         "typescript": "^5.8.2"
       }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
+      "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@drizzle-team/brocli": {
       "version": "0.10.2",
@@ -968,11 +979,166 @@
         "node-pre-gyp": "bin/node-pre-gyp"
       }
     },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@noble/hashes": "1.3.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@petamoriken/float16": {
       "version": "3.9.3",
       "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.9.3.tgz",
       "integrity": "sha512-8awtpHXCx/bNpFt4mt2xdkgtgVvKqty8VbjHI/WWWQuEw+KLzFot3f4+LkQY9YmOtq7A5GdOnqoIC8Pdygjk2g==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
+      "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.9.0",
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32/node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
+      "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@spruceid/siwe-parser": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@spruceid/siwe-parser/-/siwe-parser-2.1.2.tgz",
+      "integrity": "sha512-d/r3S1LwJyMaRAKQ0awmo9whfXeE88Qt00vRj91q5uv5ATtWIQEGJ67Yr5eSZw5zp1/fZCXZYuEckt8lSkereQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/hashes": "^1.1.2",
+        "apg-js": "^4.3.0",
+        "uri-js": "^4.4.1",
+        "valid-url": "^1.0.9"
+      }
+    },
+    "node_modules/@stablelib/binary": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/binary/-/binary-1.0.1.tgz",
+      "integrity": "sha512-ClJWvmL6UBM/wjkvv/7m5VP3GMr9t0osr4yVgLZsLCOz4hGN9gIAFEqnJ0TsSMAN+n840nf2cHZnA5/KFqHC7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/int": "^1.0.1"
+      }
+    },
+    "node_modules/@stablelib/int": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/int/-/int-1.0.1.tgz",
+      "integrity": "sha512-byr69X/sDtDiIjIV6m4roLVWnNNlRGzsvxw+agj8CIEazqWGOQp2dTYgQhtyVXV9wpO6WyXRQUzLV/JRNumT2w==",
+      "license": "MIT"
+    },
+    "node_modules/@stablelib/random": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@stablelib/random/-/random-1.0.2.tgz",
+      "integrity": "sha512-rIsE83Xpb7clHPVRlBj8qNe5L8ISQOzjghYQm/dZ7VaM2KHYwMW5adjQjrzTZCchFnNCNhkwtnOBa9HTMJCI8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/binary": "^1.0.1",
+        "@stablelib/wipe": "^1.0.1"
+      }
+    },
+    "node_modules/@stablelib/wipe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/wipe/-/wipe-1.0.1.tgz",
+      "integrity": "sha512-WfqfX/eXGiAd3RJe4VU2snh/ZPwtSjLG4ynQ/vYzvghTh7dHFcI1wl+nrkWG6lGhukOxOsUHfv8dUXr58D0ayg==",
       "license": "MIT"
     },
     "node_modules/@types/bcrypt": {
@@ -1007,11 +1173,95 @@
         "pg-types": "^2.2.0"
       }
     },
+    "node_modules/@x402/core": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@x402/core/-/core-2.6.0.tgz",
+      "integrity": "sha512-ISC/JeVss6xlKvor2rp18tJf9K5OQlIDDfZW1VZJQGDI2F4gy+HWxxkFfcQalCsPp4YUlwqh0YOkUxP+LTZWVg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "zod": "^3.24.2"
+      }
+    },
+    "node_modules/@x402/evm": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@x402/evm/-/evm-2.6.0.tgz",
+      "integrity": "sha512-wPkNHf483gie1Up2sJSvERnW+VIEvMoT1KRXr09wSoSWgelglsJm+ug3gPPXKnT3C6AcmNAKZ12rBnu9Paff7g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@x402/core": "~2.6.0",
+        "@x402/extensions": "~2.6.0",
+        "viem": "^2.39.3",
+        "zod": "^3.24.2"
+      }
+    },
+    "node_modules/@x402/extensions": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@x402/extensions/-/extensions-2.6.0.tgz",
+      "integrity": "sha512-aLY9xAOOiRLKDN9HT2r9TYUXbD+IsoBces9qPZNVJGO2TBi2rfmbIBc3pcKCtWKn3iTvG2QFr3gpOFdpJRzqww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scure/base": "^1.2.6",
+        "@x402/core": "~2.6.0",
+        "ajv": "^8.17.1",
+        "siwe": "^2.3.2",
+        "tweetnacl": "^1.0.3",
+        "viem": "^2.43.5",
+        "zod": "^3.24.2"
+      }
+    },
+    "node_modules/@x402/hono": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@x402/hono/-/hono-2.6.0.tgz",
+      "integrity": "sha512-Wt+7Ik6gnVNEY57O+A8/hueL9j+DvbNtHvvqKkTvpq6gadvU2ZtOn++0sWtDIFKRaTq3MVix/rWKlNCRoG0hDQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@x402/core": "~2.6.0",
+        "@x402/extensions": "~2.6.0",
+        "zod": "^3.24.2"
+      },
+      "peerDependencies": {
+        "@x402/paywall": "2.6.0",
+        "hono": "^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@x402/paywall": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "license": "ISC"
+    },
+    "node_modules/abitype": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.3.tgz",
+      "integrity": "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/wevm"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4",
+        "zod": "^3.22.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/aes-js": {
+      "version": "4.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/agent-base": {
       "version": "6.0.2",
@@ -1025,6 +1275,22 @@
         "node": ">= 6.0.0"
       }
     },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -1033,6 +1299,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/apg-js": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/apg-js/-/apg-js-4.4.0.tgz",
+      "integrity": "sha512-fefmXFknJmtgtNEXfPwZKYkMFX4Fyeyz+fNF6JWp87biGOPslJbCBVU158zvKRZfHBKnJDy8CMM40oLFGkXT8Q==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/aproba": {
       "version": "2.1.0",
@@ -1804,6 +2076,80 @@
         "esbuild": ">=0.12 <1"
       }
     },
+    "node_modules/ethers": {
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.16.0.tgz",
+      "integrity": "sha512-U1wulmetNymijEhpSEQ7Ct/P/Jw9/e7R1j5XIbPRydgV2DjLVMsULDlNksq3RQnFgKoLlZf88ijYtWEXcPa07A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/ethers-io/"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@adraffy/ens-normalize": "1.10.1",
+        "@noble/curves": "1.2.0",
+        "@noble/hashes": "1.3.2",
+        "@types/node": "22.7.5",
+        "aes-js": "4.0.0-beta.5",
+        "tslib": "2.7.0",
+        "ws": "8.17.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/ethers/node_modules/@types/node": {
+      "version": "22.7.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
+      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/ethers/node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fs-minipass": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
@@ -1989,6 +2335,21 @@
         "node": ">=18"
       }
     },
+    "node_modules/isows": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.7.tgz",
+      "integrity": "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
     "node_modules/jose": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.1.tgz",
@@ -1997,6 +2358,12 @@
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/make-dir": {
       "version": "3.1.0",
@@ -2158,6 +2525,69 @@
         "wrappy": "1"
       }
     },
+    "node_modules/ox": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.0.tgz",
+      "integrity": "sha512-WLOB7IKnmI3Ol6RAqY7CJdZKl8QaI44LN91OGF1061YIeN6bL5IsFcdp7+oQShRyamE/8fW/CBRWhJAOzI35Dw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.11.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "abitype": "^1.2.3",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ox/node_modules/@adraffy/ens-normalize": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
+      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
+      "license": "MIT"
+    },
+    "node_modules/ox/node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ox/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -2295,6 +2725,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -2307,6 +2746,15 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve-pkg-maps": {
@@ -2391,6 +2839,21 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
+    },
+    "node_modules/siwe": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/siwe/-/siwe-2.3.2.tgz",
+      "integrity": "sha512-aSf+6+Latyttbj5nMu6GF3doMfv2UYj83hhwZgUF20ky6fTS83uVhkQABdIVnEuS8y1bBdk7p6ltb9SmlhTTlA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@spruceid/siwe-parser": "^2.1.2",
+        "@stablelib/random": "^1.0.1",
+        "uri-js": "^4.4.1",
+        "valid-url": "^1.0.9"
+      },
+      "peerDependencies": {
+        "ethers": "^5.6.8 || ^6.0.8"
+      }
     },
     "node_modules/source-map": {
       "version": "0.6.1",
@@ -2480,6 +2943,13 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tsx": {
       "version": "4.21.0",
@@ -2985,11 +3455,17 @@
         "@esbuild/win32-x64": "0.27.4"
       }
     },
+    "node_modules/tweetnacl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
+      "license": "Unlicense"
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -3006,11 +3482,103 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/valid-url": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
+      "integrity": "sha512-QQDsV8OnSf5Uc30CKSwG9lnhMPe6exHtTXLRYX8uMwKENy640pU+2BgBL0LRbDh/eYRahNCS7aewCx0wf3NYVA=="
+    },
+    "node_modules/viem": {
+      "version": "2.47.2",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.47.2.tgz",
+      "integrity": "sha512-etDIwDgmDiGaPg8rUbJtUFuC3/nAJCbhMYyfh5dOcqNNkzBWTNcS2VluPSM5JVo+9U3b2hle2RkBEq3+xyvlvg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "1.8.0",
+        "@scure/bip32": "1.7.0",
+        "@scure/bip39": "1.6.0",
+        "abitype": "1.2.3",
+        "isows": "1.0.7",
+        "ox": "0.14.0",
+        "ws": "8.18.3"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/viem/node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/viem/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/viem/node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
@@ -3059,6 +3627,28 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
     },
+    "node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -3073,6 +3663,15 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,12 +20,16 @@
   },
   "dependencies": {
     "@hono/node-server": "^1.13.7",
+    "@x402/core": "^2.6.0",
+    "@x402/evm": "^2.6.0",
+    "@x402/hono": "^2.6.0",
     "bcrypt": "^5.1.1",
     "dotenv": "^16.4.7",
     "drizzle-orm": "^0.39.3",
     "hono": "^4.7.4",
     "jose": "^6.2.1",
-    "pg": "^8.13.3"
+    "pg": "^8.13.3",
+    "viem": "^2.47.2"
   },
   "devDependencies": {
     "@types/bcrypt": "^5.0.2",

--- a/src/db/schema/agents.ts
+++ b/src/db/schema/agents.ts
@@ -17,6 +17,7 @@ export const agents = pgTable('agents', {
   webhookUrl: text('webhook_url'),
   webhookSecret: varchar('webhook_secret', { length: 64 }),
   a2aCardUrl: text('a2a_card_url'),                                       // A2A Agent Card URL
+  evmAddress: varchar('evm_address', { length: 42 }),                     // EVM wallet address for USDC payouts
   apiKeyHash: varchar('api_key_hash', { length: 128 }).notNull(),         // bcrypt hash of API key
   lastApiCallAt: timestamp('last_api_call_at', { withTimezone: true }),   // For emission eligibility
   verifiedAt: timestamp('verified_at', { withTimezone: true }),

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -12,3 +12,4 @@ export { idempotencyKeys } from './idempotency_keys.js';
 export { a2aTaskContexts } from './a2a_task_contexts.js';
 import { a2aTaskContexts } from './a2a_task_contexts.js';
 export type A2ATaskContextRow = typeof a2aTaskContexts.$inferSelect;
+export { x402Payments } from './x402_payments.js';

--- a/src/db/schema/tasks.ts
+++ b/src/db/schema/tasks.ts
@@ -18,6 +18,8 @@ export const tasks = pgTable('tasks', {
   validationRequired: boolean('validation_required').default(true),
   executorAgentId: varchar('executor_agent_id', { length: 12 }).references(() => agents.id),
   systemTask: boolean('system_task').default(false),                        // Platform-generated task
+  paymentMode: varchar('payment_mode', { length: 10 }).notNull().default('points'), // 'points' | 'usdc'
+  escrowTxHash: varchar('escrow_tx_hash', { length: 128 }),               // x402 on-chain escrow tx
   createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
   updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow(),
 }, (table) => [

--- a/src/db/schema/x402_payments.ts
+++ b/src/db/schema/x402_payments.ts
@@ -1,0 +1,17 @@
+import { pgTable, bigserial, varchar, decimal, timestamp, index } from 'drizzle-orm/pg-core';
+import { tasks } from './tasks.js';
+
+export const x402Payments = pgTable('x402_payments', {
+  id: bigserial('id', { mode: 'number' }).primaryKey(),
+  taskId: varchar('task_id', { length: 12 }).references(() => tasks.id),
+  payerAddress: varchar('payer_address', { length: 42 }).notNull(),
+  recipientAddress: varchar('recipient_address', { length: 42 }).notNull(),
+  amountUsdc: decimal('amount_usdc', { precision: 12, scale: 6 }).notNull(),
+  txHash: varchar('tx_hash', { length: 128 }).notNull().unique(),
+  network: varchar('network', { length: 20 }).notNull(),
+  paymentType: varchar('payment_type', { length: 20 }).notNull(), // 'escrow' | 'payout' | 'refund'
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
+}, (table) => [
+  index('idx_x402_payments_task').on(table.taskId),
+  index('idx_x402_payments_payer').on(table.payerAddress),
+]);

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import { publicRouter } from './routes/public.js';
 import { dashboardRouter } from './routes/dashboard.js';
 import { internalRouter } from './routes/internal.js';
 import { a2aRouter } from './routes/a2a.js';
+import { x402Router } from './routes/x402.js';
 
 const app = new Hono();
 
@@ -34,8 +35,8 @@ app.use(
       return allowed.includes(origin) ? origin : 'https://upmoltwork.mingles.ai';
     },
     allowMethods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
-    allowHeaders: ['Content-Type', 'Authorization', 'Idempotency-Key'],
-    exposeHeaders: ['X-RateLimit-Remaining'],
+    allowHeaders: ['Content-Type', 'Authorization', 'Idempotency-Key', 'X-PAYMENT', 'Payment-Signature'],
+    exposeHeaders: ['X-RateLimit-Remaining', 'PAYMENT-REQUIRED', 'PAYMENT-RESPONSE'],
     maxAge: 86400,
     credentials: true,
   }),
@@ -124,6 +125,13 @@ app.get('/.well-known/agent.json', (c) =>
       },
     ],
     authentication: { schemes: ['bearer'] },
+    x402: {
+      networks: [process.env.BASE_NETWORK ?? 'eip155:84532'],
+      facilitator: process.env.FACILITATOR_URL ?? 'https://facilitator.x402.org',
+      payTo: process.env.PLATFORM_EVM_ADDRESS ?? '',
+      tasksEndpoint: 'https://api.upmoltwork.mingles.ai/v1/x402/tasks',
+      infoEndpoint: 'https://api.upmoltwork.mingles.ai/v1/x402/info',
+    },
   }),
 );
 
@@ -139,6 +147,7 @@ app.route('/v1/public', publicRouter);
 app.route('/v1/dashboard', dashboardRouter);
 app.route('/v1/internal', internalRouter);
 app.route('/a2a', a2aRouter);
+app.route('/v1/x402', x402Router);
 
 // ---------------------------------------------------------------------------
 // Start server

--- a/src/lib/usdc-transfer.ts
+++ b/src/lib/usdc-transfer.ts
@@ -1,0 +1,169 @@
+import { createWalletClient, createPublicClient, http, parseUnits, formatUnits } from 'viem';
+import { privateKeyToAccount } from 'viem/accounts';
+import { baseSepolia, base } from 'viem/chains';
+import { db } from '../db/pool.js';
+import { x402Payments } from '../db/schema/index.js';
+
+const PLATFORM_PRIVATE_KEY = process.env.PLATFORM_EVM_PRIVATE_KEY as `0x${string}`;
+const PLATFORM_EVM_ADDRESS = process.env.PLATFORM_EVM_ADDRESS as `0x${string}`;
+const BASE_NETWORK = process.env.BASE_NETWORK ?? 'eip155:84532';
+
+// USDC contract addresses by network
+const USDC_CONTRACTS: Record<string, `0x${string}`> = {
+  'eip155:84532': '0x036CbD53842c5426634e7929541eC2318f3dCF7e', // Base Sepolia
+  'eip155:8453': '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',  // Base Mainnet
+};
+
+// RPC endpoints by network
+const RPC_URLS: Record<string, string> = {
+  'eip155:84532': 'https://sepolia.base.org',
+  'eip155:8453': 'https://mainnet.base.org',
+};
+
+const CHAIN_BY_NETWORK: Record<string, typeof baseSepolia | typeof base> = {
+  'eip155:84532': baseSepolia,
+  'eip155:8453': base,
+};
+
+// ERC-20 transfer ABI
+const ERC20_ABI = [
+  {
+    name: 'transfer',
+    type: 'function',
+    stateMutability: 'nonpayable',
+    inputs: [
+      { name: 'to', type: 'address' },
+      { name: 'amount', type: 'uint256' },
+    ],
+    outputs: [{ name: '', type: 'bool' }],
+  },
+  {
+    name: 'balanceOf',
+    type: 'function',
+    stateMutability: 'view',
+    inputs: [{ name: 'account', type: 'address' }],
+    outputs: [{ name: '', type: 'uint256' }],
+  },
+] as const;
+
+const USDC_DECIMALS = 6;
+const PLATFORM_FEE_RATE = 0.05; // 5%
+
+function getChain() {
+  return CHAIN_BY_NETWORK[BASE_NETWORK] ?? baseSepolia;
+}
+
+function getUsdcContract(): `0x${string}` {
+  const addr = USDC_CONTRACTS[BASE_NETWORK];
+  if (!addr) throw new Error(`No USDC contract for network ${BASE_NETWORK}`);
+  return addr;
+}
+
+function getWalletClient() {
+  const account = privateKeyToAccount(PLATFORM_PRIVATE_KEY);
+  return createWalletClient({
+    account,
+    chain: getChain(),
+    transport: http(RPC_URLS[BASE_NETWORK] ?? 'https://sepolia.base.org'),
+  });
+}
+
+function getPublicClient() {
+  return createPublicClient({
+    chain: getChain(),
+    transport: http(RPC_URLS[BASE_NETWORK] ?? 'https://sepolia.base.org'),
+  });
+}
+
+/**
+ * Transfer USDC from platform wallet to a recipient.
+ * Applies 5% platform fee (platform keeps fee, sends remainder).
+ * Records payment in x402_payments.
+ */
+export async function transferUsdc(opts: {
+  to: `0x${string}`;
+  amountUsdc: number; // gross amount before fee
+  taskId?: string;
+}): Promise<string> {
+  const { to, amountUsdc, taskId } = opts;
+  const netAmount = amountUsdc * (1 - PLATFORM_FEE_RATE);
+  const amountWei = parseUnits(netAmount.toFixed(USDC_DECIMALS), USDC_DECIMALS);
+
+  const walletClient = getWalletClient();
+  const usdcContract = getUsdcContract();
+
+  const txHash = await walletClient.writeContract({
+    address: usdcContract,
+    abi: ERC20_ABI,
+    functionName: 'transfer',
+    args: [to, amountWei],
+  });
+
+  // Record in DB
+  await db.insert(x402Payments).values({
+    taskId: taskId ?? null,
+    payerAddress: PLATFORM_EVM_ADDRESS,
+    recipientAddress: to,
+    amountUsdc: netAmount.toFixed(USDC_DECIMALS),
+    txHash,
+    network: BASE_NETWORK,
+    paymentType: 'payout',
+  });
+
+  console.log(`[usdc-transfer] Paid ${netAmount} USDC (net, after 5% fee) to ${to}. tx: ${txHash}`);
+  return txHash;
+}
+
+/**
+ * Refund USDC from platform wallet back to payer.
+ * Sends full amount (no fee on refunds).
+ */
+export async function refundUsdc(opts: {
+  to: `0x${string}`;
+  amountUsdc: number;
+  taskId?: string;
+}): Promise<string> {
+  const { to, amountUsdc, taskId } = opts;
+  const amountWei = parseUnits(amountUsdc.toFixed(USDC_DECIMALS), USDC_DECIMALS);
+
+  const walletClient = getWalletClient();
+  const usdcContract = getUsdcContract();
+
+  const txHash = await walletClient.writeContract({
+    address: usdcContract,
+    abi: ERC20_ABI,
+    functionName: 'transfer',
+    args: [to, amountWei],
+  });
+
+  // Record in DB
+  await db.insert(x402Payments).values({
+    taskId: taskId ?? null,
+    payerAddress: PLATFORM_EVM_ADDRESS,
+    recipientAddress: to,
+    amountUsdc: amountUsdc.toFixed(USDC_DECIMALS),
+    txHash,
+    network: BASE_NETWORK,
+    paymentType: 'refund',
+  });
+
+  console.log(`[usdc-transfer] Refunded ${amountUsdc} USDC to ${to}. tx: ${txHash}`);
+  return txHash;
+}
+
+/**
+ * Get platform USDC balance.
+ */
+export async function getPlatformUsdcBalance(): Promise<string> {
+  const publicClient = getPublicClient();
+  const usdcContract = getUsdcContract();
+  const balance = await publicClient.readContract({
+    address: usdcContract,
+    abi: ERC20_ABI,
+    functionName: 'balanceOf',
+    args: [PLATFORM_EVM_ADDRESS],
+  });
+  return formatUnits(balance as bigint, USDC_DECIMALS);
+}
+
+export { USDC_CONTRACTS, BASE_NETWORK as CURRENT_NETWORK };

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -2,6 +2,7 @@ import { eq, and, sql, isNotNull } from 'drizzle-orm';
 import { db } from '../db/pool.js';
 import { agents, validations, submissions, tasks, a2aTaskContexts } from '../db/schema/index.js';
 import { releaseEscrowToExecutor, refundEscrow, systemCredit } from './transfer.js';
+import { transferUsdc } from './usdc-transfer.js';
 import { generateValidationId } from './ids.js';
 import { fireWebhook } from './webhooks.js';
 import { updateReputation, REPUTATION } from './reputation.js';
@@ -103,14 +104,52 @@ async function applyApproval(submissionId: string): Promise<void> {
   if (!sub || sub.status !== 'validating') return;
   const [t] = await db.select().from(tasks).where(eq(tasks.id, sub.taskId)).limit(1);
   if (!t) return;
-  const price = parseFloat(t.pricePoints ?? '0');
+
   await db.update(submissions).set({ status: 'approved' }).where(eq(submissions.id, submissionId));
   await db.update(tasks).set({ status: 'completed', updatedAt: new Date() }).where(eq(tasks.id, sub.taskId));
-  await releaseEscrowToExecutor({
-    taskId: sub.taskId,
-    executorAgentId: sub.agentId,
-    totalAmount: price,
-  });
+
+  if (t.paymentMode === 'usdc') {
+    // USDC payout: transfer from platform wallet to executor's evm_address
+    const [executor] = await db.select({ evmAddress: agents.evmAddress })
+      .from(agents)
+      .where(eq(agents.id, sub.agentId))
+      .limit(1);
+
+    if (!executor?.evmAddress) {
+      // Executor has no EVM address — hold funds, send webhook warning
+      console.warn(`[validation] Executor ${sub.agentId} has no evm_address — USDC payout held for task ${sub.taskId}`);
+      fireWebhook(sub.agentId, 'payment.held', {
+        task_id: sub.taskId,
+        submission_id: submissionId,
+        reason: 'no_evm_address',
+        message: 'Set evm_address via PATCH /v1/agents/me to receive USDC payout',
+      });
+    } else {
+      const priceUsdc = parseFloat(t.priceUsdc ?? '0');
+      try {
+        await transferUsdc({
+          to: executor.evmAddress as `0x${string}`,
+          amountUsdc: priceUsdc,
+          taskId: sub.taskId,
+        });
+      } catch (err) {
+        console.error(`[validation] USDC transfer failed for task ${sub.taskId}:`, err);
+        fireWebhook(sub.agentId, 'payment.failed', {
+          task_id: sub.taskId,
+          submission_id: submissionId,
+          error: err instanceof Error ? err.message : 'Unknown error',
+        });
+      }
+    }
+  } else {
+    // Points payout (default)
+    const price = parseFloat(t.pricePoints ?? '0');
+    await releaseEscrowToExecutor({
+      taskId: sub.taskId,
+      executorAgentId: sub.agentId,
+      totalAmount: price,
+    });
+  }
   await db.update(agents).set({
     tasksCompleted: sql`tasks_completed + 1`,
     updatedAt: sql`NOW()`,

--- a/src/lib/x402.ts
+++ b/src/lib/x402.ts
@@ -1,0 +1,17 @@
+import { paymentMiddleware, x402ResourceServer } from '@x402/hono';
+import { ExactEvmScheme } from '@x402/evm/exact/server';
+import { HTTPFacilitatorClient } from '@x402/core/server';
+
+export const PLATFORM_EVM_ADDRESS = process.env.PLATFORM_EVM_ADDRESS as `0x${string}`;
+export const FACILITATOR_URL = process.env.FACILITATOR_URL ?? 'https://facilitator.x402.org';
+export const BASE_NETWORK = (process.env.BASE_NETWORK ?? 'eip155:84532') as string;
+
+if (!PLATFORM_EVM_ADDRESS) {
+  throw new Error('PLATFORM_EVM_ADDRESS environment variable is required');
+}
+
+export const facilitatorClient = new HTTPFacilitatorClient({ url: FACILITATOR_URL });
+export const resourceServer = new x402ResourceServer(facilitatorClient)
+  .register(BASE_NETWORK as `eip155:${string}`, new ExactEvmScheme());
+
+export { paymentMiddleware };

--- a/src/routes/agents.ts
+++ b/src/routes/agents.ts
@@ -143,6 +143,7 @@ agentsRouter.get('/me', authMiddleware, rateLimitMiddleware, async (c) => {
     tasks_completed: agent.tasksCompleted ?? 0,
     tasks_created: agent.tasksCreated ?? 0,
     success_rate: parseFloat(agent.successRate ?? '0'),
+    evm_address: agent.evmAddress ?? null,
     specializations: agent.specializations ?? [],
     webhook_url: agent.webhookUrl,
     webhook_secret: agent.webhookSecret ? `${agent.webhookSecret.slice(0, 8)}...` : null,
@@ -179,6 +180,18 @@ agentsRouter.patch('/me', authMiddleware, rateLimitMiddleware, async (c) => {
   if (typeof b.a2a_agent_card_url === 'string')
     updates.a2aCardUrl = b.a2a_agent_card_url.trim() || null;
 
+  // x402: EVM wallet address for USDC payouts
+  if (typeof b.evm_address === 'string') {
+    const addr = b.evm_address.trim();
+    if (addr && !/^0x[a-fA-F0-9]{40}$/.test(addr)) {
+      return c.json(
+        { error: 'invalid_request', message: 'evm_address must be a valid EVM address (0x + 40 hex chars)' },
+        400,
+      );
+    }
+    updates.evmAddress = addr || null;
+  }
+
   if (Object.keys(updates).length === 0) {
     return c.json({ error: 'invalid_request', message: 'No valid fields to update' }, 400);
   }
@@ -196,6 +209,7 @@ agentsRouter.patch('/me', authMiddleware, rateLimitMiddleware, async (c) => {
     owner_twitter: updated!.ownerTwitter,
     status: updated!.status,
     balance_points: parseFloat(updated!.balancePoints ?? '0'),
+    evm_address: updated!.evmAddress ?? null,
     specializations: updated!.specializations ?? [],
     webhook_url: updated!.webhookUrl,
     a2a_card_url: updated!.a2aCardUrl,

--- a/src/routes/tasks.ts
+++ b/src/routes/tasks.ts
@@ -186,6 +186,8 @@ tasksRouter.get('/', async (c) => {
       description: t.description,
       acceptance_criteria: t.acceptanceCriteria,
       price_points: t.pricePoints ? parseFloat(t.pricePoints) : null,
+      price_usdc: t.priceUsdc ? parseFloat(t.priceUsdc) : null,
+      payment_mode: t.paymentMode ?? 'points',
       status: t.status,
       deadline: t.deadline?.toISOString() ?? null,
       created_at: t.createdAt?.toISOString(),
@@ -214,6 +216,8 @@ tasksRouter.get('/:id', async (c) => {
     description: t.description,
     acceptance_criteria: t.acceptanceCriteria,
     price_points: t.pricePoints ? parseFloat(t.pricePoints) : null,
+    price_usdc: t.priceUsdc ? parseFloat(t.priceUsdc) : null,
+    payment_mode: t.paymentMode ?? 'points',
     status: t.status,
     deadline: t.deadline?.toISOString() ?? null,
     executor_agent_id: t.executorAgentId,
@@ -328,6 +332,17 @@ tasksRouter.post('/:taskId/bids', authMiddleware, rateLimitMiddleware, async (c)
     return c.json({ error: 'conflict', message: 'Task not open for bids' }, 409);
   if (t.creatorAgentId === agent.id)
     return c.json({ error: 'forbidden', message: 'Cannot bid on own task' }, 403);
+
+  // x402: USDC tasks require bidder to have an evm_address for payout
+  if (t.paymentMode === 'usdc' && !agent.evmAddress) {
+    return c.json(
+      {
+        error: 'evm_address_required',
+        message: 'USDC tasks require an EVM address. Set it via PATCH /v1/agents/me with {"evm_address": "0x..."}',
+      },
+      422,
+    );
+  }
 
   let body: unknown;
   try {

--- a/src/routes/x402.ts
+++ b/src/routes/x402.ts
@@ -1,0 +1,186 @@
+import { Hono } from 'hono';
+import { eq, sql } from 'drizzle-orm';
+import { db } from '../db/pool.js';
+import { agents, tasks, type AgentRow } from '../db/schema/index.js';
+import { authMiddleware } from '../auth.js';
+import { generateTaskId } from '../lib/ids.js';
+import { rateLimitMiddleware } from '../middleware/rateLimit.js';
+import { paymentMiddleware, resourceServer, PLATFORM_EVM_ADDRESS, BASE_NETWORK } from '../lib/x402.js';
+import { fireWebhook } from '../lib/webhooks.js';
+
+// USDC contract addresses by network (informational)
+const USDC_CONTRACTS: Record<string, string> = {
+  'eip155:84532': '0x036CbD53842c5426634e7929541eC2318f3dCF7e',
+  'eip155:8453': '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+};
+
+const TASK_CATEGORIES = [
+  'content', 'images', 'video', 'marketing',
+  'development', 'prototypes', 'analytics', 'validation',
+] as const;
+
+const MIN_PRICE_USDC = 0.01;
+
+type AppVariables = { agent: AgentRow; agentId: string };
+
+export const x402Router = new Hono<{ Variables: AppVariables }>();
+
+// ---------------------------------------------------------------------------
+// GET /v1/x402/info — platform info for x402 payments
+// ---------------------------------------------------------------------------
+x402Router.get('/info', (c) =>
+  c.json({
+    platform_address: PLATFORM_EVM_ADDRESS,
+    network: BASE_NETWORK,
+    facilitator: process.env.FACILITATOR_URL ?? 'https://facilitator.x402.org',
+    usdc_contract: USDC_CONTRACTS[BASE_NETWORK] ?? null,
+    fee_rate: 0.05,
+    description: 'UpMoltWork x402 payment endpoint — pay USDC to create tasks',
+  }),
+);
+
+// ---------------------------------------------------------------------------
+// POST /v1/x402/tasks?price_usdc=<n>
+// Create a USDC-priced task via x402 payment protocol.
+// Step 1: Auth middleware (agent must be authenticated)
+// Step 2: Validate price_usdc query param
+// Step 3: x402 payment middleware — returns 402 if no X-PAYMENT header
+// Step 4: Route handler — task is created after payment verified & settled
+// ---------------------------------------------------------------------------
+
+// Auth middleware
+x402Router.use('/tasks', authMiddleware);
+
+// Price validation + x402 payment middleware (dynamic pricing via query param)
+x402Router.use('/tasks', async (c, next) => {
+  const priceUsdc = parseFloat(c.req.query('price_usdc') ?? '0');
+  if (isNaN(priceUsdc) || priceUsdc < MIN_PRICE_USDC) {
+    return c.json(
+      { error: 'invalid_request', message: `price_usdc must be >= ${MIN_PRICE_USDC}` },
+      400,
+    );
+  }
+
+  // Build x402 payment middleware with dynamic price from query param.
+  // The path must match c.req.path which will be /v1/x402/tasks (full path after mount).
+  const middleware = paymentMiddleware(
+    {
+      'POST /v1/x402/tasks': {
+        accepts: {
+          scheme: 'exact',
+          price: `$${priceUsdc.toFixed(2)}`,
+          network: BASE_NETWORK as `eip155:${string}`,
+          payTo: PLATFORM_EVM_ADDRESS,
+        },
+        description: 'Create a USDC-priced task on UpMoltWork',
+        mimeType: 'application/json',
+      },
+    },
+    resourceServer,
+    undefined,
+    undefined,
+    false, // don't sync facilitator on every request (already initialized on startup)
+  );
+
+  return middleware(c, next);
+});
+
+// Route handler (runs only after payment is verified and settled by middleware)
+x402Router.post('/tasks', rateLimitMiddleware, async (c) => {
+  const agent = c.get('agent');
+  if (agent.status !== 'verified') {
+    return c.json({ error: 'forbidden', message: 'Verified agents only can create tasks' }, 403);
+  }
+
+  const priceUsdc = parseFloat(c.req.query('price_usdc') ?? '0');
+
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: 'invalid_request', message: 'Invalid JSON body' }, 400);
+  }
+
+  const b = body as Record<string, unknown>;
+  const category = typeof b.category === 'string' ? b.category : 'development';
+  const title = typeof b.title === 'string' ? b.title.trim() : '';
+  const description = typeof b.description === 'string' ? b.description.trim() : '';
+
+  if (!TASK_CATEGORIES.includes(category as typeof TASK_CATEGORIES[number])) {
+    return c.json({ error: 'invalid_request', message: 'Invalid category' }, 400);
+  }
+  if (!title || title.length > 200) {
+    return c.json({ error: 'invalid_request', message: 'title required (max 200)' }, 400);
+  }
+  if (!description) {
+    return c.json({ error: 'invalid_request', message: 'description required' }, 400);
+  }
+
+  const acceptanceCriteria = Array.isArray(b.acceptance_criteria)
+    ? (b.acceptance_criteria as string[])
+        .filter((s): s is string => typeof s === 'string')
+        .slice(0, 20)
+    : [description.slice(0, 200)];
+
+  const deadline = typeof b.deadline === 'string' ? new Date(b.deadline) : null;
+  const taskId = generateTaskId();
+
+  // Attempt to extract escrow tx hash from the payment header if available
+  const paymentHeader = c.req.header('x-payment') ?? c.req.header('payment-signature');
+  let escrowTxHash: string | null = null;
+  if (paymentHeader) {
+    try {
+      const decoded = Buffer.from(paymentHeader, 'base64').toString('utf-8');
+      const parsed = JSON.parse(decoded) as Record<string, unknown>;
+      escrowTxHash = (parsed?.transaction as string) ?? (parsed?.tx_hash as string) ?? null;
+    } catch {
+      // non-critical, best-effort
+    }
+  }
+
+  await db.insert(tasks).values({
+    id: taskId,
+    creatorAgentId: agent.id,
+    category,
+    title,
+    description,
+    acceptanceCriteria,
+    priceUsdc: priceUsdc.toFixed(6),
+    pricePoints: null,
+    status: 'open',
+    deadline: deadline ?? null,
+    autoAcceptFirst: Boolean(b.auto_accept_first),
+    maxBids: typeof b.max_bids === 'number' ? Math.min(b.max_bids, 20) : 10,
+    validationRequired: b.validation_required !== false,
+    paymentMode: 'usdc',
+    escrowTxHash,
+  });
+
+  await db.update(agents)
+    .set({ tasksCreated: sql`tasks_created + 1`, updatedAt: sql`NOW()` })
+    .where(eq(agents.id, agent.id));
+
+  fireWebhook(agent.id, 'task.created', {
+    task_id: taskId,
+    payment_mode: 'usdc',
+    price_usdc: priceUsdc,
+  });
+
+  const [task] = await db.select().from(tasks).where(eq(tasks.id, taskId)).limit(1);
+
+  return c.json(
+    {
+      id: task!.id,
+      category: task!.category,
+      title: task!.title,
+      description: task!.description,
+      acceptance_criteria: task!.acceptanceCriteria,
+      price_usdc: parseFloat(task!.priceUsdc ?? '0'),
+      payment_mode: task!.paymentMode,
+      status: task!.status,
+      deadline: task!.deadline?.toISOString() ?? null,
+      created_at: task!.createdAt?.toISOString(),
+    },
+    201,
+  );
+});

--- a/src/tests/a2a.test.ts
+++ b/src/tests/a2a.test.ts
@@ -104,6 +104,7 @@ function makeAgent(id: string): AgentRow {
     tasksCreated: 0,
     successRate: '0',
     specializations: [],
+    evmAddress: null,
     webhookUrl: null,
     webhookSecret: null,
     a2aCardUrl: null,


### PR DESCRIPTION
## Summary

Implements x402 payment protocol support alongside the existing Points system. Agents can now create tasks and receive rewards in either **Points OR USDC on Base Sepolia**.

## Changes

### New Files
- `src/lib/x402.ts` — paymentMiddleware + x402ResourceServer setup with Base Sepolia
- `src/lib/usdc-transfer.ts` — viem ERC-20 USDC transfers (5% platform fee on payouts, full refunds)
- `src/routes/x402.ts` — `GET /v1/x402/info` + `POST /v1/x402/tasks` (402 protected with dynamic pricing)
- `src/db/schema/x402_payments.ts` — x402_payments table for tracking all USDC flows
- `drizzle/migrations/0003_x402_protocol.sql` — DB migration (applied to live DB)

### Modified Files
- `src/db/schema/agents.ts` — added `evm_address` field
- `src/db/schema/tasks.ts` — added `payment_mode` + `escrow_tx_hash` fields
- `src/db/schema/index.ts` — export x402Payments
- `src/routes/agents.ts` — PATCH/GET `/me` support for `evm_address` with 0x validation
- `src/routes/tasks.ts` — bid validation: USDC tasks require bidder `evm_address` (422)
- `src/lib/validation.ts` — `applyApproval()` routes USDC payouts via `transferUsdc()`
- `src/index.ts` — mount `x402Router`, update CORS headers, add x402 to agent.json
- `src/tests/a2a.test.ts` — add `evmAddress: null` to test mock

## Flow

```
POST /v1/x402/tasks?price_usdc=5.00 (no X-PAYMENT) → 402 + payment instructions
Agent pays USDC on-chain → POST again with X-PAYMENT → task created
Validation approval → viem transfers USDC to executor's evm_address (minus 5% fee)
```

## Testing Checklist
- [x] GET /v1/x402/info → returns platform address + network
- [x] POST /v1/x402/tasks (no auth) → 401
- [x] POST /v1/x402/tasks (auth, no X-PAYMENT) → 402
- [x] PATCH /v1/agents/me with {"evm_address": "0x..."} → 200
- [x] Agent without evm_address cannot bid on USDC task → 422
- [x] TypeScript build passes cleanly
- [x] DB migration applied on live DB

Addresses issue #28