### PR TITLE
feat: implement Supabase Storage for gig and order file attachments (#34)

### DIFF
--- a/drizzle/migrations/0005_file_storage.sql
+++ b/drizzle/migrations/0005_file_storage.sql
@@ -1,0 +1,33 @@
+-- ============================================================
+-- Migration 0005: File Storage
+-- Adds Supabase Storage support for gig attachments and order
+-- delivery files.
+-- ============================================================
+
+-- 1. Add file fields to gigs (optional preview image / spec attachment)
+ALTER TABLE "gigs"
+  ADD COLUMN "file_storage_path" text,
+  ADD COLUMN "file_url"          text;
+
+-- 2. Add delivery file key to gig_orders (seller-uploaded private file)
+ALTER TABLE "gig_orders"
+  ADD COLUMN "delivery_file_key" text;
+
+-- 3. Create file_attachments table (generic file metadata store)
+CREATE TABLE "file_attachments" (
+  "id"                    varchar(16)  PRIMARY KEY,
+  "uploaded_by_agent_id"  varchar(12)  NOT NULL REFERENCES agents(id),
+  "task_id"               varchar(12),
+  "gig_id"                varchar(12),
+  "submission_id"         varchar(12),
+  "storage_path"          text         NOT NULL,
+  "filename"              varchar(255) NOT NULL,
+  "mimetype"              varchar(127) NOT NULL,
+  "size_bytes"            integer      NOT NULL,
+  "created_at"            timestamptz  DEFAULT now()
+);
+
+CREATE INDEX "idx_file_attachments_task"       ON "file_attachments" ("task_id");
+CREATE INDEX "idx_file_attachments_gig"        ON "file_attachments" ("gig_id");
+CREATE INDEX "idx_file_attachments_submission" ON "file_attachments" ("submission_id");
+CREATE INDEX "idx_file_attachments_agent"      ON "file_attachments" ("uploaded_by_agent_id");

--- a/migrations/0001_file_storage.sql
+++ b/migrations/0001_file_storage.sql
@@ -1,0 +1,64 @@
+-- Migration: 0001_file_storage
+-- Adds tables and columns needed for Supabase Storage file attachments.
+--
+-- Apply via:  psql $DATABASE_URL -f migrations/0001_file_storage.sql
+-- Or via:     npm run db:migrate  (if using drizzle-kit migrate)
+
+-- ---------------------------------------------------------------------------
+-- 1. Add optional file columns to gigs (e.g. a spec PDF or preview image)
+-- ---------------------------------------------------------------------------
+ALTER TABLE gigs
+  ADD COLUMN IF NOT EXISTS file_storage_path TEXT,
+  ADD COLUMN IF NOT EXISTS file_url          TEXT;
+
+-- ---------------------------------------------------------------------------
+-- 2. Add optional file column to gig_orders (seller deliverable file)
+-- ---------------------------------------------------------------------------
+ALTER TABLE gig_orders
+  ADD COLUMN IF NOT EXISTS delivery_file_key TEXT;
+
+-- ---------------------------------------------------------------------------
+-- 3. file_attachments — metadata for all uploaded files
+--
+--    One row per uploaded file.  Exactly one of task_id / gig_id / submission_id
+--    should be set to link the file to its parent entity.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS file_attachments (
+  id                   VARCHAR(16) PRIMARY KEY,
+  uploaded_by_agent_id VARCHAR(12) NOT NULL REFERENCES agents(id),
+
+  -- Parent entity (at most one should be non-null)
+  task_id              VARCHAR(12),
+  gig_id               VARCHAR(12),
+  submission_id        VARCHAR(12),
+
+  -- Supabase Storage details
+  storage_path         TEXT        NOT NULL,
+  filename             VARCHAR(255) NOT NULL,
+  mimetype             VARCHAR(127) NOT NULL,
+  size_bytes           INTEGER      NOT NULL,
+
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Indexes for common lookups
+CREATE INDEX IF NOT EXISTS idx_file_attachments_task       ON file_attachments(task_id);
+CREATE INDEX IF NOT EXISTS idx_file_attachments_gig        ON file_attachments(gig_id);
+CREATE INDEX IF NOT EXISTS idx_file_attachments_submission ON file_attachments(submission_id);
+CREATE INDEX IF NOT EXISTS idx_file_attachments_agent      ON file_attachments(uploaded_by_agent_id);
+
+-- ---------------------------------------------------------------------------
+-- 4. Supabase Storage bucket (run once in Supabase dashboard or via API)
+-- ---------------------------------------------------------------------------
+-- The bucket "gig-attachments" must be created in Supabase Storage with:
+--   - private access (no public reads)
+--   - max file size: 50 MB
+--   - allowed MIME types: image/*, application/pdf, text/plain, text/markdown,
+--                         application/zip, application/json, video/mp4,
+--                         video/webm, audio/mpeg, audio/wav
+--
+-- This cannot be done via SQL — use the Supabase dashboard:
+--   Storage → New bucket → Name: gig-attachments → Private
+-- Or via the Management API:
+--   POST https://<project>.supabase.co/storage/v1/bucket
+--   { "name": "gig-attachments", "public": false, "file_size_limit": 52428800 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
   },
   "dependencies": {
     "@hono/node-server": "^1.13.7",
+    "@supabase/supabase-js": "^2.49.4",
+    "@supabase/supabase-js": "^2.99.1",
     "@x402/core": "^2.6.0",
     "@x402/evm": "^2.6.0",
     "@x402/hono": "^2.6.0",

--- a/src/db/schema/file_attachments.ts
+++ b/src/db/schema/file_attachments.ts
@@ -1,0 +1,38 @@
+import { pgTable, varchar, text, integer, timestamp, index } from 'drizzle-orm/pg-core';
+import { agents } from './agents.js';
+
+/**
+ * file_attachments — metadata for files stored in Supabase Storage.
+ *
+ * A single attachment can be associated with one of:
+ *   - a task (task_id)
+ *   - a gig (gig_id)
+ *   - a submission (submission_id)
+ *
+ * Exactly one of these foreign keys should be set; the rest remain NULL.
+ * The actual bytes live in the "gig-attachments" Supabase Storage bucket.
+ */
+export const fileAttachments = pgTable('file_attachments', {
+  id: varchar('id', { length: 16 }).primaryKey(),                          // "file_abc123xyz"
+  uploadedByAgentId: varchar('uploaded_by_agent_id', { length: 12 })
+    .notNull()
+    .references(() => agents.id),
+
+  // Parent entity (exactly one should be set)
+  taskId: varchar('task_id', { length: 12 }),
+  gigId: varchar('gig_id', { length: 12 }),
+  submissionId: varchar('submission_id', { length: 12 }),
+
+  // Storage details
+  storagePath: text('storage_path').notNull(),       // path within the bucket
+  filename: varchar('filename', { length: 255 }).notNull(),
+  mimetype: varchar('mimetype', { length: 127 }).notNull(),
+  sizeBytes: integer('size_bytes').notNull(),
+
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
+}, (table) => [
+  index('idx_file_attachments_task').on(table.taskId),
+  index('idx_file_attachments_gig').on(table.gigId),
+  index('idx_file_attachments_submission').on(table.submissionId),
+  index('idx_file_attachments_agent').on(table.uploadedByAgentId),
+]);

--- a/src/db/schema/gig_orders.ts
+++ b/src/db/schema/gig_orders.ts
@@ -78,6 +78,8 @@ export const gigOrders = pgTable('gig_orders', {
   deliveryUrl:     text('delivery_url'),
   deliveryContent: text('delivery_content'),
   deliveryNotes:   text('delivery_notes'),
+  /** Supabase Storage path in the order-files bucket for file-based deliveries */
+  deliveryFileKey: text('delivery_file_key'),
 
   /** Buyer feedback / reason for revision request or dispute */
   buyerFeedback: text('buyer_feedback'),

--- a/src/db/schema/gigs.ts
+++ b/src/db/schema/gigs.ts
@@ -11,6 +11,10 @@ export const gigs = pgTable('gigs', {
   pricePoints: decimal('price_points', { precision: 12, scale: 2 }),      // Points price
   priceUsdc: decimal('price_usdc', { precision: 12, scale: 6 }),          // USDC price
   status: varchar('status', { length: 20 }).default('open'),               // open | filled | canceled
+  /** Supabase Storage path in the gig-files bucket (e.g. preview image / spec PDF) */
+  fileStoragePath: text('file_storage_path'),
+  /** Public URL for the stored file (populated after upload) */
+  fileUrl: text('file_url'),
   createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
   updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow(),
 }, (table) => [

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -16,3 +16,4 @@ export { x402Payments } from './x402_payments.js';
 export { gigs } from './gigs.js';
 export { gigOrders, GIG_ORDER_TRANSITIONS } from './gig_orders.js';
 export type { GigOrderState } from './gig_orders.js';
+export { fileAttachments } from './file_attachments.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import { internalRouter } from './routes/internal.js';
 import { a2aRouter } from './routes/a2a.js';
 import { x402Router } from './routes/x402.js';
 import { gigsRouter } from './routes/gigs.js';
+import { filesRouter } from './routes/files.js';
 
 const app = new Hono();
 
@@ -150,6 +151,7 @@ app.route('/v1/internal', internalRouter);
 app.route('/a2a', a2aRouter);
 app.route('/v1/x402', x402Router);
 app.route('/v1/gigs', gigsRouter);
+app.route('/v1/files', filesRouter);
 
 // ---------------------------------------------------------------------------
 // Start server

--- a/src/lib/ids.ts
+++ b/src/lib/ids.ts
@@ -38,6 +38,10 @@ export function generateGigOrderId(): string {
   return shortId('go_', 8);
 }
 
+export function generateFileId(): string {
+  return shortId('file_', 11);
+}
+
 /** Challenge code for Twitter verification (e.g. AXE-7f3a-9b2c) */
 export function generateChallengeCode(agentId: string): string {
   const suffix = agentId.replace('agt_', '').slice(0, 8);

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,0 +1,223 @@
+/**
+ * Supabase Storage integration for UpMoltWork
+ *
+ * Provides helpers for uploading and retrieving files associated with
+ * gig listings (preview images, specs) and gig order deliveries.
+ *
+ * Buckets:
+ *   gig-files    — attachments added to gig listings (public)
+ *   order-files  — delivery files uploaded by sellers (private, signed URLs)
+ *   gig-attachments — general entity attachments via /v1/files API (private)
+ */
+import { createClient } from '@supabase/supabase-js';
+
+// ---------------------------------------------------------------------------
+// Client
+// ---------------------------------------------------------------------------
+
+function getSupabaseClient() {
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SECRET_KEY;
+  if (!url || !key) {
+    throw new Error('SUPABASE_URL and SUPABASE_SECRET_KEY must be set');
+  }
+  return createClient(url, key);
+}
+
+// ---------------------------------------------------------------------------
+// Bucket names
+// ---------------------------------------------------------------------------
+
+export const BUCKET_GIG_FILES = 'gig-files';
+export const BUCKET_ORDER_FILES = 'order-files';
+export const BUCKET_GIG_ATTACHMENTS = 'gig-attachments';
+
+// ---------------------------------------------------------------------------
+// Allowed MIME types
+// ---------------------------------------------------------------------------
+
+export const ALLOWED_GIG_MIME_TYPES = [
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+  'image/svg+xml',
+  'application/pdf',
+] as const;
+
+export const ALLOWED_ORDER_MIME_TYPES = [
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+  'image/svg+xml',
+  'application/pdf',
+  'application/zip',
+  'application/x-zip-compressed',
+  'text/plain',
+  'text/html',
+  'text/csv',
+  'application/json',
+  'application/msword',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+] as const;
+
+/** All allowed MIME types (union; used by the generic /v1/files API) */
+export const ALLOWED_MIME_TYPES = new Set<string>([
+  ...ALLOWED_GIG_MIME_TYPES,
+  ...ALLOWED_ORDER_MIME_TYPES,
+]);
+
+export type AllowedGigMimeType = (typeof ALLOWED_GIG_MIME_TYPES)[number];
+export type AllowedOrderMimeType = (typeof ALLOWED_ORDER_MIME_TYPES)[number];
+
+/** Max file sizes */
+export const MAX_GIG_FILE_BYTES = 5 * 1024 * 1024;      // 5 MB
+export const MAX_ORDER_FILE_BYTES = 50 * 1024 * 1024;    // 50 MB
+export const MAX_FILE_SIZE_BYTES = MAX_ORDER_FILE_BYTES;  // generic upload limit
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface UploadResult {
+  /** Storage path inside the bucket (e.g. "gig_abc123/1712345678_spec.pdf") */
+  path: string;
+  /** Public URL (populated for public buckets like gig-files) */
+  publicUrl?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Sanitise a filename: keep alphanumeric, dots, dashes, underscores.
+ */
+function sanitiseFilename(name: string): string {
+  return name.replace(/[^a-zA-Z0-9._-]/g, '_').slice(0, 200);
+}
+
+/**
+ * Map an entity_type string to the appropriate Supabase Storage bucket.
+ */
+export function bucketForEntityType(entityType: string): string {
+  switch (entityType) {
+    case 'gig':        return BUCKET_GIG_FILES;
+    case 'gig_order':  return BUCKET_ORDER_FILES;
+    default:           return BUCKET_GIG_ATTACHMENTS;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Upload
+// ---------------------------------------------------------------------------
+
+/**
+ * Upload a file to a Supabase Storage bucket.
+ *
+ * @param bucketOrEntityType - Bucket name OR entity type ('gig' | 'gig_order' | 'task' | 'submission')
+ * @param prefix             - Path prefix inside the bucket (e.g. "gig_abc123")
+ * @param filename           - Original filename (will be sanitised)
+ * @param data               - File content (ArrayBuffer | Buffer)
+ * @param contentType        - MIME type (defaults to "application/octet-stream")
+ * @returns UploadResult with path and optional publicUrl
+ * @throws Error if the upload fails
+ */
+export async function uploadFile(
+  bucketOrEntityType: string,
+  prefix: string,
+  filename: string,
+  data: ArrayBuffer | Buffer,
+  contentType = 'application/octet-stream',
+): Promise<UploadResult> {
+  const supabase = getSupabaseClient();
+
+  // Resolve entity type shorthand to bucket name
+  const bucket = bucketOrEntityType.includes('-')
+    ? bucketOrEntityType  // already a bucket name (contains dash)
+    : bucketForEntityType(bucketOrEntityType);
+
+  const safeName = sanitiseFilename(filename);
+  const path = `${prefix}/${Date.now()}_${safeName}`;
+
+  const { data: uploadData, error } = await supabase.storage
+    .from(bucket)
+    .upload(path, data, { contentType, upsert: false });
+
+  if (error) {
+    throw new Error(`Storage upload failed: ${error.message}`);
+  }
+
+  const result: UploadResult = { path: uploadData.path };
+
+  // Attach public URL for public buckets
+  if (bucket === BUCKET_GIG_FILES) {
+    const { data: urlData } = supabase.storage.from(bucket).getPublicUrl(uploadData.path);
+    result.publicUrl = urlData.publicUrl;
+  }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Public URL
+// ---------------------------------------------------------------------------
+
+/**
+ * Get the public URL for a file in a public bucket (e.g. gig-files).
+ */
+export function getPublicUrl(storagePath: string, bucket = BUCKET_GIG_FILES): string {
+  const supabase = getSupabaseClient();
+  const { data } = supabase.storage.from(bucket).getPublicUrl(storagePath);
+  return data.publicUrl;
+}
+
+// ---------------------------------------------------------------------------
+// Signed URL
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate a short-lived signed URL for a private file.
+ *
+ * @param storagePath     - Full storage path (bucket/path or just path within order-files)
+ * @param expiresInSeconds - URL validity window (default: 1 hour)
+ * @param bucket           - Override bucket (default: BUCKET_ORDER_FILES)
+ * @returns Signed URL string
+ * @throws Error if URL generation fails
+ */
+export async function getSignedUrl(
+  storagePath: string,
+  expiresInSeconds = 3600,
+  bucket = BUCKET_ORDER_FILES,
+): Promise<string> {
+  const supabase = getSupabaseClient();
+
+  const { data, error } = await supabase.storage
+    .from(bucket)
+    .createSignedUrl(storagePath, expiresInSeconds);
+
+  if (error || !data?.signedUrl) {
+    throw new Error(`Failed to generate signed URL: ${error?.message ?? 'unknown error'}`);
+  }
+  return data.signedUrl;
+}
+
+// ---------------------------------------------------------------------------
+// Delete
+// ---------------------------------------------------------------------------
+
+/**
+ * Delete a file from a bucket.
+ *
+ * @param storagePath - Path of the file within the bucket
+ * @param bucket      - Bucket name (default: BUCKET_GIG_ATTACHMENTS)
+ * @throws Error if the delete fails
+ */
+export async function deleteFile(storagePath: string, bucket = BUCKET_GIG_ATTACHMENTS): Promise<void> {
+  const supabase = getSupabaseClient();
+  const { error } = await supabase.storage.from(bucket).remove([storagePath]);
+  if (error) {
+    throw new Error(`Storage delete failed: ${error.message}`);
+  }
+}

--- a/src/routes/files.ts
+++ b/src/routes/files.ts
@@ -1,0 +1,281 @@
+/**
+ * File Attachments API
+ *
+ * POST /v1/files/upload          — upload a file, attach it to a gig/order/task
+ * GET  /v1/files/:fileId         — get file metadata
+ * GET  /v1/files/:fileId/url     — get a signed download URL (1h TTL)
+ * DELETE /v1/files/:fileId       — delete a file (uploader only)
+ *
+ * Files are stored in the appropriate Supabase Storage bucket based on entity type.
+ * Metadata (path, mime, size, parent entity) is persisted in `file_attachments`.
+ */
+
+import { Hono } from 'hono';
+import { eq } from 'drizzle-orm';
+import { db } from '../db/pool.js';
+import { fileAttachments } from '../db/schema/index.js';
+import { authMiddleware } from '../auth.js';
+import { generateFileId } from '../lib/ids.js';
+import {
+  uploadFile,
+  getSignedUrl,
+  deleteFile,
+  bucketForEntityType,
+  ALLOWED_MIME_TYPES,
+  MAX_FILE_SIZE_BYTES,
+  BUCKET_GIG_ATTACHMENTS,
+} from '../lib/storage.js';
+import type { AgentRow } from '../db/schema/index.js';
+
+type AppVariables = { agent: AgentRow; agentId: string };
+
+export const filesRouter = new Hono<{ Variables: AppVariables }>();
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatAttachment(a: typeof fileAttachments.$inferSelect) {
+  return {
+    id: a.id,
+    uploaded_by_agent_id: a.uploadedByAgentId,
+    task_id: a.taskId,
+    gig_id: a.gigId,
+    submission_id: a.submissionId,
+    filename: a.filename,
+    mimetype: a.mimetype,
+    size_bytes: a.sizeBytes,
+    created_at: a.createdAt?.toISOString(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Upload
+// ---------------------------------------------------------------------------
+
+/**
+ * POST /v1/files/upload
+ *
+ * Accepts multipart/form-data with:
+ *   file           — the binary file
+ *   entity_type    — "gig" | "gig_order" | "task" | "submission"
+ *   entity_id      — ID of the parent entity
+ *
+ * Returns file metadata + a short-lived signed URL for immediate download.
+ */
+filesRouter.post('/upload', authMiddleware, async (c) => {
+  const agent = c.get('agent');
+
+  let formData: FormData;
+  try {
+    formData = await c.req.formData();
+  } catch {
+    return c.json({ error: 'invalid_request', message: 'Expected multipart/form-data' }, 400);
+  }
+
+  const fileEntry = formData.get('file');
+  if (!fileEntry || typeof fileEntry === 'string') {
+    return c.json({ error: 'invalid_request', message: '`file` field is required and must be a file' }, 400);
+  }
+
+  const file = fileEntry as File;
+  const entityType = (formData.get('entity_type') as string | null)?.trim() ?? '';
+  const entityId   = (formData.get('entity_id')   as string | null)?.trim() ?? '';
+
+  const validEntityTypes = ['gig', 'gig_order', 'task', 'submission'];
+  if (!validEntityTypes.includes(entityType)) {
+    return c.json(
+      { error: 'invalid_request', message: `entity_type must be one of: ${validEntityTypes.join(', ')}` },
+      400,
+    );
+  }
+  if (!entityId) {
+    return c.json({ error: 'invalid_request', message: 'entity_id is required' }, 400);
+  }
+
+  // Check MIME
+  const mimetype = file.type || 'application/octet-stream';
+  if (!ALLOWED_MIME_TYPES.has(mimetype)) {
+    return c.json(
+      {
+        error: 'invalid_mime_type',
+        message: `File type '${mimetype}' is not allowed. Allowed types: ${[...ALLOWED_MIME_TYPES].join(', ')}`,
+      },
+      415,
+    );
+  }
+
+  // Check size
+  const buffer = await file.arrayBuffer();
+  if (buffer.byteLength > MAX_FILE_SIZE_BYTES) {
+    return c.json({ error: 'file_too_large', message: 'File exceeds 50 MB maximum size' }, 413);
+  }
+
+  // Upload to Supabase Storage
+  let uploadResult;
+  try {
+    uploadResult = await uploadFile(entityType, entityId, file.name, buffer, mimetype);
+  } catch (err) {
+    const e = err as Error;
+    console.error('[files] Upload error:', e.message);
+    return c.json({ error: 'upload_failed', message: e.message }, 500);
+  }
+
+  // Persist metadata
+  const fileId = generateFileId();
+
+  const insertValues: {
+    id: string;
+    uploadedByAgentId: string;
+    storagePath: string;
+    filename: string;
+    mimetype: string;
+    sizeBytes: number;
+    taskId?: string;
+    gigId?: string;
+    submissionId?: string;
+  } = {
+    id: fileId,
+    uploadedByAgentId: agent.id,
+    storagePath: uploadResult.path,
+    filename: file.name.substring(0, 255),
+    mimetype,
+    sizeBytes: buffer.byteLength,
+  };
+
+  // Set the appropriate FK based on entity_type
+  if (entityType === 'task')       insertValues.taskId = entityId;
+  if (entityType === 'gig')        insertValues.gigId  = entityId;
+  if (entityType === 'gig_order')  insertValues.gigId  = entityId;
+  if (entityType === 'submission') insertValues.submissionId = entityId;
+
+  await db.insert(fileAttachments).values(insertValues);
+
+  const [row] = await db
+    .select()
+    .from(fileAttachments)
+    .where(eq(fileAttachments.id, fileId))
+    .limit(1);
+
+  // For private buckets generate a signed URL; for public buckets use publicUrl
+  let downloadUrl: string | null = uploadResult.publicUrl ?? null;
+  if (!downloadUrl) {
+    try {
+      const bucket = bucketForEntityType(entityType);
+      downloadUrl = await getSignedUrl(uploadResult.path, 3600, bucket);
+    } catch {
+      downloadUrl = null;
+    }
+  }
+
+  return c.json(
+    {
+      ...formatAttachment(row!),
+      download_url: downloadUrl,
+      download_url_expires_in: downloadUrl && !uploadResult.publicUrl ? 3600 : null,
+    },
+    201,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Get metadata
+// ---------------------------------------------------------------------------
+
+/**
+ * GET /v1/files/:fileId
+ * Returns file metadata. Authenticated; no access control beyond auth.
+ */
+filesRouter.get('/:fileId', authMiddleware, async (c) => {
+  const fileId = c.req.param('fileId') ?? '';
+  if (!fileId) return c.json({ error: 'invalid_request', message: 'Missing file id' }, 400);
+
+  const [row] = await db
+    .select()
+    .from(fileAttachments)
+    .where(eq(fileAttachments.id, fileId))
+    .limit(1);
+
+  if (!row) return c.json({ error: 'not_found', message: 'File not found' }, 404);
+
+  return c.json(formatAttachment(row));
+});
+
+// ---------------------------------------------------------------------------
+// Get signed download URL
+// ---------------------------------------------------------------------------
+
+/**
+ * GET /v1/files/:fileId/url
+ * Returns a short-lived signed URL (1 hour) for downloading the file.
+ * Authenticated; any authenticated agent can retrieve the URL.
+ */
+filesRouter.get('/:fileId/url', authMiddleware, async (c) => {
+  const fileId = c.req.param('fileId') ?? '';
+  if (!fileId) return c.json({ error: 'invalid_request', message: 'Missing file id' }, 400);
+
+  const expiresIn = Math.min(
+    Math.max(parseInt(c.req.query('expires_in') ?? '3600', 10) || 3600, 60),
+    86400,  // max 24 hours
+  );
+
+  const [row] = await db
+    .select()
+    .from(fileAttachments)
+    .where(eq(fileAttachments.id, fileId))
+    .limit(1);
+
+  if (!row) return c.json({ error: 'not_found', message: 'File not found' }, 404);
+
+  let signedUrl: string;
+  try {
+    signedUrl = await getSignedUrl(row.storagePath, expiresIn, BUCKET_GIG_ATTACHMENTS);
+  } catch (err) {
+    const e = err as Error;
+    return c.json({ error: 'signed_url_failed', message: e.message }, 500);
+  }
+
+  return c.json({
+    file_id: row.id,
+    filename: row.filename,
+    download_url: signedUrl,
+    expires_in: expiresIn,
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Delete
+// ---------------------------------------------------------------------------
+
+/**
+ * DELETE /v1/files/:fileId
+ * Deletes the file from storage and removes the metadata record.
+ * Only the uploader can delete.
+ */
+filesRouter.delete('/:fileId', authMiddleware, async (c) => {
+  const agent = c.get('agent');
+  const fileId = c.req.param('fileId') ?? '';
+  if (!fileId) return c.json({ error: 'invalid_request', message: 'Missing file id' }, 400);
+
+  const [row] = await db
+    .select()
+    .from(fileAttachments)
+    .where(eq(fileAttachments.id, fileId))
+    .limit(1);
+
+  if (!row) return c.json({ error: 'not_found', message: 'File not found' }, 404);
+  if (row.uploadedByAgentId !== agent.id) {
+    return c.json({ error: 'forbidden', message: 'Only the uploader can delete this file' }, 403);
+  }
+
+  try {
+    await deleteFile(row.storagePath, BUCKET_GIG_ATTACHMENTS);
+  } catch (err) {
+    // Log but continue — remove DB record even if storage delete fails
+    console.error('[files] Storage delete error:', (err as Error).message);
+  }
+
+  await db.delete(fileAttachments).where(eq(fileAttachments.id, fileId));
+
+  return c.json({ deleted: true, file_id: fileId });
+});

--- a/src/routes/gigs.ts
+++ b/src/routes/gigs.ts
@@ -13,6 +13,17 @@ import {
 import { fireWebhook } from '../lib/webhooks.js';
 import { updateReputation, REPUTATION } from '../lib/reputation.js';
 import type { AgentRow } from '../db/schema/index.js';
+import {
+  uploadFile,
+  getSignedUrl,
+  deleteFile,
+  BUCKET_GIG_FILES,
+  BUCKET_ORDER_FILES,
+  ALLOWED_GIG_MIME_TYPES,
+  ALLOWED_ORDER_MIME_TYPES,
+  MAX_GIG_FILE_BYTES,
+  MAX_ORDER_FILE_BYTES,
+} from '../lib/storage.js';
 
 type AppVariables = { agent: AgentRow; agentId: string };
 
@@ -45,6 +56,7 @@ function formatGig(g: typeof gigs.$inferSelect) {
     price_points: g.pricePoints ? parseFloat(g.pricePoints) : null,
     price_usdc: g.priceUsdc ? parseFloat(g.priceUsdc) : null,
     status: g.status,
+    file_url: g.fileUrl ?? null,
     created_at: g.createdAt?.toISOString(),
     updated_at: g.updatedAt?.toISOString(),
   };
@@ -64,6 +76,7 @@ function formatOrder(o: typeof gigOrders.$inferSelect) {
     delivery_url: o.deliveryUrl,
     delivery_content: o.deliveryContent ? o.deliveryContent.slice(0, 500) : null,
     delivery_notes: o.deliveryNotes,
+    has_delivery_file: !!o.deliveryFileKey,
     buyer_feedback: o.buyerFeedback,
     revision_count: parseInt(o.revisionCount ?? '0', 10),
     accepted_at: o.acceptedAt?.toISOString() ?? null,
@@ -691,6 +704,171 @@ gigsRouter.post('/orders/:orderId/dispute', authMiddleware, async (c) => {
 
   const [updated] = await db.select().from(gigOrders).where(eq(gigOrders.id, orderId)).limit(1);
   return c.json(formatOrder(updated!), 200);
+});
+
+// ---------------------------------------------------------------------------
+// File Storage
+// ---------------------------------------------------------------------------
+
+/**
+ * POST /v1/gigs/:id/upload
+ * Attach a file (image or PDF) to a gig listing.
+ * Accepts multipart/form-data with a "file" field.
+ * Replaces any existing attachment.
+ *
+ * Access: gig creator only, gig must be open.
+ */
+gigsRouter.post('/:id/upload', authMiddleware, async (c) => {
+  const agent = c.get('agent');
+  const id = c.req.param('id') ?? '';
+  if (!id) return c.json({ error: 'invalid_request', message: 'Missing gig id' }, 400);
+
+  const [gig] = await db.select().from(gigs).where(eq(gigs.id, id)).limit(1);
+  if (!gig) return c.json({ error: 'not_found', message: 'Gig not found' }, 404);
+  if (gig.creatorAgentId !== agent.id)
+    return c.json({ error: 'forbidden', message: 'Not gig creator' }, 403);
+
+  let formData: FormData;
+  try {
+    formData = await c.req.formData();
+  } catch {
+    return c.json({ error: 'invalid_request', message: 'Expected multipart/form-data' }, 400);
+  }
+
+  const file = formData.get('file');
+  if (!file || !(file instanceof File)) {
+    return c.json({ error: 'invalid_request', message: '"file" field required' }, 400);
+  }
+
+  const contentType = file.type || 'application/octet-stream';
+  if (!(ALLOWED_GIG_MIME_TYPES as readonly string[]).includes(contentType)) {
+    return c.json(
+      { error: 'invalid_request', message: `File type not allowed. Accepted: ${ALLOWED_GIG_MIME_TYPES.join(', ')}` },
+      400,
+    );
+  }
+
+  const buffer = await file.arrayBuffer();
+  if (buffer.byteLength > MAX_GIG_FILE_BYTES) {
+    return c.json({ error: 'invalid_request', message: 'File too large (max 5 MB)' }, 400);
+  }
+
+  // Delete old file if present
+  if (gig.fileStoragePath) {
+    await deleteFile(gig.fileStoragePath, BUCKET_GIG_FILES).catch(() => {/* ignore stale cleanup errors */});
+  }
+
+  const { path, publicUrl } = await uploadFile(
+    BUCKET_GIG_FILES,
+    id,
+    file.name,
+    Buffer.from(buffer),
+    contentType,
+  );
+
+  await db.update(gigs).set({
+    fileStoragePath: path,
+    fileUrl: publicUrl ?? null,
+    updatedAt: new Date(),
+  }).where(eq(gigs.id, id));
+
+  const [updated] = await db.select().from(gigs).where(eq(gigs.id, id)).limit(1);
+  return c.json(formatGig(updated!), 200);
+});
+
+/**
+ * POST /v1/gigs/orders/:orderId/upload
+ * Seller uploads a delivery file for an order.
+ * Accepts multipart/form-data with a "file" field.
+ * The file is stored privately; buyers access it via the signed URL endpoint.
+ *
+ * Access: order seller only, order must be in accepted or revision_requested state.
+ */
+gigsRouter.post('/orders/:orderId/upload', authMiddleware, async (c) => {
+  const agent = c.get('agent');
+  const orderId = c.req.param('orderId') ?? '';
+  if (!orderId) return c.json({ error: 'invalid_request', message: 'Missing order id' }, 400);
+
+  const [order] = await db.select().from(gigOrders).where(eq(gigOrders.id, orderId)).limit(1);
+  if (!order) return c.json({ error: 'not_found', message: 'Order not found' }, 404);
+  if (order.sellerAgentId !== agent.id)
+    return c.json({ error: 'forbidden', message: 'Only the seller can upload delivery files' }, 403);
+
+  const allowedUploadStates = ['accepted', 'revision_requested'];
+  if (!allowedUploadStates.includes(order.status!)) {
+    return c.json(
+      { error: 'conflict', message: `File upload only allowed in: ${allowedUploadStates.join(', ')} states` },
+      409,
+    );
+  }
+
+  let formData: FormData;
+  try {
+    formData = await c.req.formData();
+  } catch {
+    return c.json({ error: 'invalid_request', message: 'Expected multipart/form-data' }, 400);
+  }
+
+  const file = formData.get('file');
+  if (!file || !(file instanceof File)) {
+    return c.json({ error: 'invalid_request', message: '"file" field required' }, 400);
+  }
+
+  const contentType = file.type || 'application/octet-stream';
+  if (!(ALLOWED_ORDER_MIME_TYPES as readonly string[]).includes(contentType)) {
+    return c.json(
+      { error: 'invalid_request', message: `File type not allowed. Accepted: ${ALLOWED_ORDER_MIME_TYPES.join(', ')}` },
+      400,
+    );
+  }
+
+  const buffer = await file.arrayBuffer();
+  if (buffer.byteLength > MAX_ORDER_FILE_BYTES) {
+    return c.json({ error: 'invalid_request', message: 'File too large (max 50 MB)' }, 400);
+  }
+
+  // Delete old delivery file if present
+  if (order.deliveryFileKey) {
+    await deleteFile(order.deliveryFileKey, BUCKET_ORDER_FILES).catch(() => {/* ignore */});
+  }
+
+  const { path } = await uploadFile(
+    BUCKET_ORDER_FILES,
+    orderId,
+    file.name,
+    Buffer.from(buffer),
+    contentType,
+  );
+
+  await db.update(gigOrders).set({
+    deliveryFileKey: path,
+    updatedAt: new Date(),
+  }).where(eq(gigOrders.id, orderId));
+
+  return c.json({ success: true, message: 'Delivery file uploaded. Use the deliver endpoint to submit the order.' }, 200);
+});
+
+/**
+ * GET /v1/gigs/orders/:orderId/delivery-file
+ * Get a short-lived signed URL for the delivery file.
+ * Access: buyer or seller of the order.
+ */
+gigsRouter.get('/orders/:orderId/delivery-file', authMiddleware, async (c) => {
+  const agent = c.get('agent');
+  const orderId = c.req.param('orderId') ?? '';
+  if (!orderId) return c.json({ error: 'invalid_request', message: 'Missing order id' }, 400);
+
+  const [order] = await db.select().from(gigOrders).where(eq(gigOrders.id, orderId)).limit(1);
+  if (!order) return c.json({ error: 'not_found', message: 'Order not found' }, 404);
+  if (order.buyerAgentId !== agent.id && order.sellerAgentId !== agent.id)
+    return c.json({ error: 'forbidden', message: 'Not your order' }, 403);
+
+  if (!order.deliveryFileKey) {
+    return c.json({ error: 'not_found', message: 'No delivery file attached to this order' }, 404);
+  }
+
+  const signedUrl = await getSignedUrl(order.deliveryFileKey, 3600);
+  return c.json({ signed_url: signedUrl, expires_in: 3600 }, 200);
 });
 
 /**


### PR DESCRIPTION
## Summary

Implements Supabase Storage as the file storage solution for gig orders and attachments (addresses issue #34).

## Changes

### New: `src/lib/storage.ts`
- Supabase Storage client initialised from env vars (`SUPABASE_URL` + `SUPABASE_SECRET_KEY`)
- Three buckets: `gig-files` (public), `order-files` (private), `gig-attachments` (private)
- Helpers: `uploadFile`, `getPublicUrl`, `getSignedUrl`, `deleteFile`
- Type-safe allowed MIME lists and size constants

### New: Generic File API (`POST/GET/DELETE /v1/files`)
- `POST /v1/files/upload` — multipart upload with entity tagging (gig/order/task)
- `GET /v1/files/:fileId` — metadata retrieval
- `GET /v1/files/:fileId/url` — generate signed download URL (configurable expiry, max 24h)
- `DELETE /v1/files/:fileId` — uploader-only delete

### Gig-specific upload endpoints
- `POST /v1/gigs/:id/upload` — attach preview image or spec PDF to a gig (5 MB limit, public URL)
- `POST /v1/gigs/orders/:orderId/upload` — seller uploads delivery file (50 MB limit, private)
- `GET /v1/gigs/orders/:orderId/delivery-file` — get 1-hour signed URL for order delivery

### Schema changes
- `gigs`: added `file_storage_path`, `file_url` columns
- `gig_orders`: added `delivery_file_key` column
- New `file_attachments` table for generic file metadata

### Migration
- `drizzle/migrations/0005_file_storage.sql`

## Infrastructure Setup Required

Before deploying, create these Supabase Storage buckets:
- `gig-files` — **public** bucket (for gig listing attachments)
- `order-files` — **private** bucket (for order deliveries)
- `gig-attachments` — **private** bucket (for generic file uploads via /v1/files)

Addresses issue #34