### PR TITLE
feat: add SQL migrations for gigs and gig_orders tables

### DIFF
--- a/migrations/2023_03_13_0001_create_gigs_table.sql
+++ b/migrations/2023_03_13_0001_create_gigs_table.sql
@@ -1,0 +1,17 @@
+CREATE TABLE gigs (
+    id VARCHAR(12) PRIMARY KEY,
+    creator_agent_id VARCHAR(12) NOT NULL REFERENCES agents(id),
+    title VARCHAR(200) NOT NULL,
+    description TEXT NOT NULL,
+    category VARCHAR(30) NOT NULL,
+    price_points DECIMAL(12, 2),
+    price_usdc DECIMAL(12, 6),
+    status VARCHAR(20) DEFAULT 'open',
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX idx_gigs_status ON gigs(status);
+CREATE INDEX idx_gigs_category ON gigs(category);
+CREATE INDEX idx_gigs_creator ON gigs(creator_agent_id);
+CREATE INDEX idx_gigs_created ON gigs(created_at);

--- a/migrations/2023_03_13_0002_create_gig_orders_table.sql
+++ b/migrations/2023_03_13_0002_create_gig_orders_table.sql
@@ -1,0 +1,61 @@
+-- Gig Orders table
+-- Tracks orders placed against gigs, including full lifecycle state machine.
+--
+-- Lifecycle:
+--   pending → accepted → delivered → completed
+--                     ↘             ↘ revision_requested → delivered
+--                       cancelled    ↘ disputed → completed | cancelled
+
+CREATE TABLE gig_orders (
+    id VARCHAR(12) PRIMARY KEY,
+
+    gig_id VARCHAR(12) NOT NULL REFERENCES gigs(id),
+
+    -- Agent who placed the order (buyer)
+    buyer_agent_id VARCHAR(12) NOT NULL REFERENCES agents(id),
+
+    -- Agent who provides the service (seller = gig creator)
+    seller_agent_id VARCHAR(12) NOT NULL REFERENCES agents(id),
+
+    -- Price snapshot at time of order (may differ from current gig price)
+    price_points DECIMAL(12, 2),
+    price_usdc   DECIMAL(12, 6),
+
+    -- Payment currency used for this order: 'points' | 'usdc'
+    payment_mode VARCHAR(10) NOT NULL DEFAULT 'points',
+
+    -- Order lifecycle state
+    status VARCHAR(20) NOT NULL DEFAULT 'pending',
+
+    -- Requirements / custom instructions from buyer
+    requirements TEXT,
+
+    -- Seller's delivery: URL or inline content
+    delivery_url     TEXT,
+    delivery_content TEXT,
+    delivery_notes   TEXT,
+
+    -- Buyer feedback / reason for revision request or dispute
+    buyer_feedback TEXT,
+
+    -- Admin dispute resolution notes
+    dispute_resolution TEXT,
+
+    -- Number of revision cycles used
+    revision_count VARCHAR(5) DEFAULT '0',
+
+    -- Timestamps for lifecycle milestones
+    accepted_at  TIMESTAMPTZ,
+    delivered_at TIMESTAMPTZ,
+    completed_at TIMESTAMPTZ,
+    cancelled_at TIMESTAMPTZ,
+
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX idx_gig_orders_gig     ON gig_orders(gig_id);
+CREATE INDEX idx_gig_orders_buyer   ON gig_orders(buyer_agent_id);
+CREATE INDEX idx_gig_orders_seller  ON gig_orders(seller_agent_id);
+CREATE INDEX idx_gig_orders_status  ON gig_orders(status);
+CREATE INDEX idx_gig_orders_created ON gig_orders(created_at);


### PR DESCRIPTION
## Summary

Addresses issue #32 — Define Gig Data Model.

The Drizzle ORM schema files (`src/db/schema/gigs.ts`, `src/db/schema/gig_orders.ts`) and full CRUD routes (`src/routes/gigs.ts` at `/v1/gigs`) were already implemented in prior PRs (#33, #37). This PR tracks the underlying SQL schema in version-controlled migration files.

## Changes

### `migrations/2023_03_13_0001_create_gigs_table.sql`
- `CREATE TABLE gigs` with all fields: `id`, `creator_agent_id`, `title`, `description`, `category`, `price_points`, `price_usdc`, `status`, timestamps
- Indices: `idx_gigs_status`, `idx_gigs_category`, `idx_gigs_creator`, `idx_gigs_created`

### `migrations/2023_03_13_0002_create_gig_orders_table.sql`
- `CREATE TABLE gig_orders` with full order lifecycle schema
- Status state machine: `pending → accepted → delivered → completed | cancelled | disputed`
- Delivery fields: `delivery_url`, `delivery_content`, `delivery_notes`
- Feedback/dispute fields: `buyer_feedback`, `dispute_resolution`, `revision_count`
- Lifecycle timestamps: `accepted_at`, `delivered_at`, `completed_at`, `cancelled_at`
- Indices: `idx_gig_orders_gig`, `idx_gig_orders_buyer`, `idx_gig_orders_seller`, `idx_gig_orders_status`, `idx_gig_orders_created`

## Checklist
- [x] `gigs` table with all required fields and indices
- [x] `gig_orders` table with full lifecycle schema and indices
- [x] CRUD endpoints for gigs (already live at `/v1/gigs` from prior work)
- [x] Build passes (`tsc` — no errors)