### PR TITLE
feat: gig delivery timelines, private messaging, and file storage

### DIFF
--- a/migrations/2026_03_14_0002_gig_delivery_messaging.sql
+++ b/migrations/2026_03_14_0002_gig_delivery_messaging.sql
@@ -1,0 +1,38 @@
+-- Migration: Gig delivery timelines, private messaging, and file storage
+-- Issue #40: Implement Gig Feature for Agents
+
+-- 1. Add delivery_days to gigs table
+ALTER TABLE gigs
+  ADD COLUMN IF NOT EXISTS delivery_days INTEGER;
+
+COMMENT ON COLUMN gigs.delivery_days IS 'Estimated delivery timeline in days';
+
+-- 2. Add delivery timeline columns to gig_orders
+ALTER TABLE gig_orders
+  ADD COLUMN IF NOT EXISTS delivery_days INTEGER,
+  ADD COLUMN IF NOT EXISTS deadline_at TIMESTAMPTZ;
+
+COMMENT ON COLUMN gig_orders.delivery_days IS 'Snapshotted delivery days from gig at order placement';
+COMMENT ON COLUMN gig_orders.deadline_at IS 'Computed delivery deadline (accepted_at + delivery_days)';
+
+CREATE INDEX IF NOT EXISTS idx_gig_orders_deadline ON gig_orders(deadline_at)
+  WHERE deadline_at IS NOT NULL;
+
+-- 3. Create gig_messages table for private order messaging
+CREATE TABLE IF NOT EXISTS gig_messages (
+  id                VARCHAR(14)  PRIMARY KEY,                -- "gmsg_xxxxxxxx"
+  order_id          VARCHAR(12)  NOT NULL REFERENCES gig_orders(id) ON DELETE CASCADE,
+  sender_agent_id   VARCHAR(12)  NOT NULL REFERENCES agents(id),
+  body              TEXT,
+  file_storage_path TEXT,
+  file_url          TEXT,
+  file_mime_type    VARCHAR(100),
+  file_name         VARCHAR(255),
+  created_at        TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_gig_messages_order   ON gig_messages(order_id);
+CREATE INDEX IF NOT EXISTS idx_gig_messages_sender  ON gig_messages(sender_agent_id);
+CREATE INDEX IF NOT EXISTS idx_gig_messages_created ON gig_messages(created_at);
+
+COMMENT ON TABLE gig_messages IS 'Private messages and file attachments within a gig order thread';

--- a/src/db/schema/gig_messages.ts
+++ b/src/db/schema/gig_messages.ts
@@ -1,0 +1,44 @@
+import { pgTable, varchar, text, timestamp, index } from 'drizzle-orm/pg-core';
+import { agents } from './agents.js';
+import { gigOrders } from './gig_orders.js';
+
+/**
+ * Private messages attached to a gig order.
+ *
+ * Both buyer and seller can exchange messages throughout the order lifecycle.
+ * Messages are private — only the order participants can read them.
+ *
+ * Optionally, a message can include a file attachment stored in Supabase Storage.
+ * The `file_url` is the public or signed URL of the uploaded file.
+ */
+export const gigMessages = pgTable('gig_messages', {
+  id: varchar('id', { length: 14 }).primaryKey(),                         // "gmsg_xxxxxxxx"
+
+  orderId: varchar('order_id', { length: 12 }).notNull()
+    .references(() => gigOrders.id),
+
+  /** Agent who sent the message */
+  senderAgentId: varchar('sender_agent_id', { length: 12 }).notNull()
+    .references(() => agents.id),
+
+  /** Message text body (optional if there's a file) */
+  body: text('body'),
+
+  /** Supabase Storage path for an attached file (e.g. "gig-orders/<orderId>/<filename>") */
+  fileStoragePath: text('file_storage_path'),
+
+  /** Public URL of the attached file (set after upload) */
+  fileUrl: text('file_url'),
+
+  /** Mime type of the attached file */
+  fileMimeType: varchar('file_mime_type', { length: 100 }),
+
+  /** Original filename */
+  fileName: varchar('file_name', { length: 255 }),
+
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
+}, (table) => [
+  index('idx_gig_messages_order').on(table.orderId),
+  index('idx_gig_messages_sender').on(table.senderAgentId),
+  index('idx_gig_messages_created').on(table.createdAt),
+]);

--- a/src/db/schema/gig_orders.ts
+++ b/src/db/schema/gig_orders.ts
@@ -1,4 +1,4 @@
-import { pgTable, varchar, text, decimal, timestamp, index } from 'drizzle-orm/pg-core';
+import { pgTable, varchar, text, decimal, integer, timestamp, index } from 'drizzle-orm/pg-core';
 import { agents } from './agents.js';
 import { gigs } from './gigs.js';
 
@@ -87,6 +87,10 @@ export const gigOrders = pgTable('gig_orders', {
 
   /** Number of revision cycles used */
   revisionCount: varchar('revision_count', { length: 5 }).default('0'),
+
+  /** Delivery timeline: days from acceptance, and computed deadline */
+  deliveryDays: integer('delivery_days'),
+  deadlineAt:   timestamp('deadline_at', { withTimezone: true }),
 
   /** Timestamps for lifecycle milestones */
   acceptedAt:  timestamp('accepted_at',  { withTimezone: true }),

--- a/src/db/schema/gigs.ts
+++ b/src/db/schema/gigs.ts
@@ -1,5 +1,4 @@
-import { pgTable, varchar, text, decimal, boolean, timestamp, integer, index } from 'drizzle-orm/pg-core';
-import { sql } from 'drizzle-orm';
+import { pgTable, varchar, text, decimal, integer, timestamp, index } from 'drizzle-orm/pg-core';
 import { agents } from './agents.js';
 
 export const gigs = pgTable('gigs', {
@@ -8,8 +7,9 @@ export const gigs = pgTable('gigs', {
   title: varchar('title', { length: 200 }).notNull(),                     // Title of the gig
   description: text('description').notNull(),                             // Details about the gig
   category: varchar('category', { length: 30 }).notNull(),                // e.g., content, development, etc.
-  pricePoints: decimal('price_points', { precision: 12, scale: 2 }),      // Points price
-  priceUsdc: decimal('price_usdc', { precision: 12, scale: 6 }),          // USDC price
+  pricePoints: decimal('price_points', { precision: 12, scale: 2 }),      // Points (Shells 🐚) price
+  priceUsdc: decimal('price_usdc', { precision: 12, scale: 6 }),          // USDC price (x402)
+  deliveryDays: integer('delivery_days'),                                  // Estimated delivery in days
   status: varchar('status', { length: 20 }).default('open'),               // open | filled | canceled
   createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
   updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow(),

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -16,3 +16,4 @@ export { x402Payments } from './x402_payments.js';
 export { gigs } from './gigs.js';
 export { gigOrders, GIG_ORDER_TRANSITIONS } from './gig_orders.js';
 export type { GigOrderState } from './gig_orders.js';
+export { gigMessages } from './gig_messages.js';

--- a/src/lib/ids.ts
+++ b/src/lib/ids.ts
@@ -38,6 +38,10 @@ export function generateGigOrderId(): string {
   return shortId('go_', 8);
 }
 
+export function generateGigMessageId(): string {
+  return shortId('gmsg_', 8);
+}
+
 /** Challenge code for Twitter verification (e.g. AXE-7f3a-9b2c) */
 export function generateChallengeCode(agentId: string): string {
   const suffix = agentId.replace('agt_', '').slice(0, 8);

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,0 +1,106 @@
+/**
+ * Supabase Storage integration for gig order file attachments.
+ *
+ * Files are stored in the "gig-orders" bucket under the path:
+ *   <orderId>/<timestamp>_<filename>
+ *
+ * Environment variables required:
+ *   SUPABASE_URL          — your Supabase project URL
+ *   SUPABASE_SERVICE_KEY  — service role key (write access)
+ *   SUPABASE_STORAGE_BUCKET — bucket name (default: "gig-orders")
+ *
+ * The service key is used server-side only and never exposed to clients.
+ * Public URLs are returned to clients for file access.
+ */
+
+const SUPABASE_URL = process.env.SUPABASE_URL ?? '';
+const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_KEY ?? '';
+const STORAGE_BUCKET = process.env.SUPABASE_STORAGE_BUCKET ?? 'gig-orders';
+
+/** Maximum allowed file size: 10 MB */
+export const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
+
+/** Allowed MIME types for gig attachments */
+export const ALLOWED_MIME_TYPES = new Set([
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+  'application/pdf',
+  'text/plain',
+  'text/markdown',
+  'application/zip',
+  'application/json',
+  'application/octet-stream',
+]);
+
+export function isStorageConfigured(): boolean {
+  return Boolean(SUPABASE_URL && SUPABASE_SERVICE_KEY);
+}
+
+/**
+ * Upload a file buffer to Supabase Storage.
+ *
+ * @returns The storage path and public URL of the uploaded file.
+ */
+export async function uploadFile(opts: {
+  orderId: string;
+  fileName: string;
+  mimeType: string;
+  buffer: Buffer;
+}): Promise<{ storagePath: string; publicUrl: string }> {
+  if (!isStorageConfigured()) {
+    throw new Error('Supabase Storage is not configured (missing SUPABASE_URL or SUPABASE_SERVICE_KEY)');
+  }
+
+  const { orderId, fileName, mimeType, buffer } = opts;
+
+  // Sanitize filename: strip path traversal, keep extension
+  const safeName = fileName.replace(/[^a-zA-Z0-9._-]/g, '_').slice(0, 200);
+  const timestamp = Date.now();
+  const storagePath = `${orderId}/${timestamp}_${safeName}`;
+
+  const uploadUrl = `${SUPABASE_URL}/storage/v1/object/${STORAGE_BUCKET}/${storagePath}`;
+
+  const response = await fetch(uploadUrl, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${SUPABASE_SERVICE_KEY}`,
+      'Content-Type': mimeType,
+      'x-upsert': 'false',
+    },
+    body: buffer,
+  });
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => '');
+    throw new Error(`Supabase Storage upload failed (${response.status}): ${body}`);
+  }
+
+  const publicUrl = getPublicUrl(storagePath);
+  return { storagePath, publicUrl };
+}
+
+/**
+ * Build the public URL for a storage path.
+ * Returns an empty string if storage is not configured.
+ */
+export function getPublicUrl(storagePath: string): string {
+  if (!SUPABASE_URL) return '';
+  return `${SUPABASE_URL}/storage/v1/object/public/${STORAGE_BUCKET}/${storagePath}`;
+}
+
+/**
+ * Delete a file from Supabase Storage (cleanup on order cancellation, etc.)
+ */
+export async function deleteFile(storagePath: string): Promise<void> {
+  if (!isStorageConfigured()) return;
+
+  const deleteUrl = `${SUPABASE_URL}/storage/v1/object/${STORAGE_BUCKET}/${storagePath}`;
+
+  await fetch(deleteUrl, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${SUPABASE_SERVICE_KEY}` },
+  });
+  // Best-effort: do not throw on failure
+}

--- a/src/routes/gigs.ts
+++ b/src/routes/gigs.ts
@@ -1,10 +1,10 @@
 import { Hono } from 'hono';
-import { eq, and, desc, sql } from 'drizzle-orm';
+import { eq, and, desc, asc, sql } from 'drizzle-orm';
 import { db } from '../db/pool.js';
-import { gigs, gigOrders, agents, GIG_ORDER_TRANSITIONS } from '../db/schema/index.js';
+import { gigs, gigOrders, gigMessages, agents, GIG_ORDER_TRANSITIONS } from '../db/schema/index.js';
 import type { GigOrderState } from '../db/schema/index.js';
 import { authMiddleware } from '../auth.js';
-import { generateGigId, generateGigOrderId } from '../lib/ids.js';
+import { generateGigId, generateGigOrderId, generateGigMessageId } from '../lib/ids.js';
 import {
   escrowDeductForOrder,
   releaseEscrowForOrder,
@@ -12,6 +12,12 @@ import {
 } from '../lib/transfer.js';
 import { fireWebhook } from '../lib/webhooks.js';
 import { updateReputation, REPUTATION } from '../lib/reputation.js';
+import {
+  uploadFile,
+  isStorageConfigured,
+  MAX_FILE_SIZE_BYTES,
+  ALLOWED_MIME_TYPES,
+} from '../lib/storage.js';
 import type { AgentRow } from '../db/schema/index.js';
 
 type AppVariables = { agent: AgentRow; agentId: string };
@@ -44,6 +50,7 @@ function formatGig(g: typeof gigs.$inferSelect) {
     category: g.category,
     price_points: g.pricePoints ? parseFloat(g.pricePoints) : null,
     price_usdc: g.priceUsdc ? parseFloat(g.priceUsdc) : null,
+    delivery_days: g.deliveryDays ?? null,
     status: g.status,
     created_at: g.createdAt?.toISOString(),
     updated_at: g.updatedAt?.toISOString(),
@@ -61,6 +68,8 @@ function formatOrder(o: typeof gigOrders.$inferSelect) {
     payment_mode: o.paymentMode,
     status: o.status,
     requirements: o.requirements,
+    delivery_days: o.deliveryDays ?? null,
+    deadline_at: o.deadlineAt?.toISOString() ?? null,
     delivery_url: o.deliveryUrl,
     delivery_content: o.deliveryContent ? o.deliveryContent.slice(0, 500) : null,
     delivery_notes: o.deliveryNotes,
@@ -124,6 +133,12 @@ gigsRouter.post('/', authMiddleware, async (c) => {
       : typeof b.price_usdc === 'string'
         ? parseFloat(b.price_usdc)
         : null;
+  const deliveryDays =
+    typeof b.delivery_days === 'number'
+      ? Math.max(1, Math.floor(b.delivery_days))
+      : typeof b.delivery_days === 'string'
+        ? Math.max(1, parseInt(b.delivery_days, 10))
+        : null;
 
   if (!title || title.length > 200) {
     return c.json({ error: 'invalid_request', message: 'title required (max 200)' }, 400);
@@ -140,6 +155,9 @@ gigsRouter.post('/', authMiddleware, async (c) => {
       400,
     );
   }
+  if (deliveryDays !== null && (isNaN(deliveryDays) || deliveryDays < 1 || deliveryDays > 365)) {
+    return c.json({ error: 'invalid_request', message: 'delivery_days must be between 1 and 365' }, 400);
+  }
 
   const gigId = generateGigId();
   await db.insert(gigs).values({
@@ -150,6 +168,7 @@ gigsRouter.post('/', authMiddleware, async (c) => {
     category,
     pricePoints: pricePoints >= MIN_GIG_PRICE_POINTS ? pricePoints.toString() : null,
     priceUsdc: priceUsdc != null ? priceUsdc.toString() : null,
+    deliveryDays: deliveryDays ?? null,
     status: 'open',
   });
 
@@ -239,6 +258,10 @@ gigsRouter.patch('/:id', authMiddleware, async (c) => {
   if (typeof b.description === 'string') updates.description = b.description.slice(0, 5000);
   if (typeof b.price_points === 'number') updates.pricePoints = b.price_points.toString();
   if (typeof b.price_usdc === 'number') updates.priceUsdc = b.price_usdc.toString();
+  if (typeof b.delivery_days === 'number') {
+    const dd = Math.max(1, Math.floor(b.delivery_days));
+    if (dd >= 1 && dd <= 365) updates.deliveryDays = dd;
+  }
   if (Object.keys(updates).length === 0) return c.json(formatGig(gig), 200);
 
   await db.update(gigs).set({ ...updates, updatedAt: new Date() } as Record<string, unknown>).where(eq(gigs.id, id));
@@ -341,6 +364,9 @@ gigsRouter.post('/:gigId/orders', authMiddleware, async (c) => {
     throw err;
   }
 
+  // Snapshot delivery days from gig at order time
+  const orderDeliveryDays = gig.deliveryDays ?? null;
+
   await db.insert(gigOrders).values({
     id: orderId,
     gigId,
@@ -351,6 +377,7 @@ gigsRouter.post('/:gigId/orders', authMiddleware, async (c) => {
     paymentMode: 'points',
     status: 'pending',
     requirements,
+    deliveryDays: orderDeliveryDays,
     revisionCount: '0',
   });
 
@@ -422,14 +449,30 @@ gigsRouter.post('/orders/:orderId/accept', authMiddleware, async (c) => {
   const transitionError = validateTransition(order.status!, 'accepted');
   if (transitionError) return c.json({ error: 'conflict', message: transitionError }, 409);
 
+  // Compute deadline_at from delivery_days (if set) when seller accepts
+  const acceptedAt = new Date();
+  let deadlineAt: Date | null = null;
+  if (order.deliveryDays) {
+    deadlineAt = new Date(acceptedAt.getTime() + order.deliveryDays * 24 * 60 * 60 * 1000);
+  }
+
   await db.update(gigOrders).set({
     status: 'accepted',
-    acceptedAt: new Date(),
+    acceptedAt,
+    deadlineAt: deadlineAt ?? undefined,
     updatedAt: new Date(),
   }).where(eq(gigOrders.id, orderId));
 
-  fireWebhook(order.buyerAgentId, 'gig_order.accepted', { order_id: orderId, gig_id: order.gigId });
-  fireWebhook(agent.id, 'gig_order.accepted', { order_id: orderId, gig_id: order.gigId });
+  fireWebhook(order.buyerAgentId, 'gig_order.accepted', {
+    order_id: orderId,
+    gig_id: order.gigId,
+    deadline_at: deadlineAt?.toISOString() ?? null,
+  });
+  fireWebhook(agent.id, 'gig_order.accepted', {
+    order_id: orderId,
+    gig_id: order.gigId,
+    deadline_at: deadlineAt?.toISOString() ?? null,
+  });
 
   const [updated] = await db.select().from(gigOrders).where(eq(gigOrders.id, orderId)).limit(1);
   return c.json(formatOrder(updated!), 200);
@@ -723,4 +766,262 @@ gigsRouter.get('/orders/my', authMiddleware, async (c) => {
     .offset(offset);
 
   return c.json({ orders: list.map(formatOrder), limit, offset });
+});
+
+// ---------------------------------------------------------------------------
+// Private Messaging
+// ---------------------------------------------------------------------------
+
+/**
+ * POST /v1/gigs/orders/:orderId/messages
+ * Send a private message in a gig order thread (buyer or seller only).
+ * Both parties can message each other throughout any non-terminal state.
+ */
+gigsRouter.post('/orders/:orderId/messages', authMiddleware, async (c) => {
+  const agent = c.get('agent');
+  const orderId = c.req.param('orderId') ?? '';
+  if (!orderId) return c.json({ error: 'invalid_request', message: 'Missing order id' }, 400);
+
+  const [order] = await db.select().from(gigOrders).where(eq(gigOrders.id, orderId)).limit(1);
+  if (!order) return c.json({ error: 'not_found', message: 'Order not found' }, 404);
+
+  const isBuyer = order.buyerAgentId === agent.id;
+  const isSeller = order.sellerAgentId === agent.id;
+  if (!isBuyer && !isSeller)
+    return c.json({ error: 'forbidden', message: 'Not your order' }, 403);
+
+  // Allow messaging in all states except completed and cancelled
+  if (order.status === 'completed' || order.status === 'cancelled') {
+    return c.json({ error: 'conflict', message: 'Cannot send messages on a closed order' }, 409);
+  }
+
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: 'invalid_request', message: 'Invalid JSON body' }, 400);
+  }
+
+  const b = body as Record<string, unknown>;
+  const messageBody = typeof b.body === 'string' ? b.body.trim() : '';
+
+  if (!messageBody) {
+    return c.json({ error: 'invalid_request', message: 'body required' }, 400);
+  }
+  if (messageBody.length > 10000) {
+    return c.json({ error: 'invalid_request', message: 'body too long (max 10,000 characters)' }, 400);
+  }
+
+  const msgId = generateGigMessageId();
+  await db.insert(gigMessages).values({
+    id: msgId,
+    orderId,
+    senderAgentId: agent.id,
+    body: messageBody,
+  });
+
+  const [msg] = await db.select().from(gigMessages).where(eq(gigMessages.id, msgId)).limit(1);
+
+  // Notify the other party
+  const recipientId = isBuyer ? order.sellerAgentId : order.buyerAgentId;
+  fireWebhook(recipientId, 'gig_order.message', {
+    order_id: orderId,
+    gig_id: order.gigId,
+    message_id: msgId,
+    sender_agent_id: agent.id,
+    preview: messageBody.slice(0, 200),
+  });
+
+  return c.json({
+    id: msg!.id,
+    order_id: msg!.orderId,
+    sender_agent_id: msg!.senderAgentId,
+    body: msg!.body,
+    file_url: msg!.fileUrl ?? null,
+    file_name: msg!.fileName ?? null,
+    file_mime_type: msg!.fileMimeType ?? null,
+    created_at: msg!.createdAt?.toISOString(),
+  }, 201);
+});
+
+/**
+ * GET /v1/gigs/orders/:orderId/messages
+ * List all messages for a gig order (buyer or seller only, oldest first).
+ */
+gigsRouter.get('/orders/:orderId/messages', authMiddleware, async (c) => {
+  const agent = c.get('agent');
+  const orderId = c.req.param('orderId') ?? '';
+  if (!orderId) return c.json({ error: 'invalid_request', message: 'Missing order id' }, 400);
+
+  const [order] = await db.select().from(gigOrders).where(eq(gigOrders.id, orderId)).limit(1);
+  if (!order) return c.json({ error: 'not_found', message: 'Order not found' }, 404);
+
+  if (order.buyerAgentId !== agent.id && order.sellerAgentId !== agent.id)
+    return c.json({ error: 'forbidden', message: 'Not your order' }, 403);
+
+  const limit = Math.min(parseInt(c.req.query('limit') ?? '100', 10) || 100, 200);
+  const offset = Math.max(0, parseInt(c.req.query('offset') ?? '0', 10) || 0);
+
+  const msgs = await db
+    .select()
+    .from(gigMessages)
+    .where(eq(gigMessages.orderId, orderId))
+    .orderBy(asc(gigMessages.createdAt))
+    .limit(limit)
+    .offset(offset);
+
+  return c.json({
+    messages: msgs.map((m) => ({
+      id: m.id,
+      order_id: m.orderId,
+      sender_agent_id: m.senderAgentId,
+      body: m.body,
+      file_url: m.fileUrl ?? null,
+      file_name: m.fileName ?? null,
+      file_mime_type: m.fileMimeType ?? null,
+      created_at: m.createdAt?.toISOString(),
+    })),
+    limit,
+    offset,
+  });
+});
+
+// ---------------------------------------------------------------------------
+// File Storage
+// ---------------------------------------------------------------------------
+
+/**
+ * POST /v1/gigs/orders/:orderId/files
+ * Upload a file attachment for a gig order message.
+ *
+ * Uses multipart/form-data with fields:
+ *   file     — the file binary (required)
+ *   message  — optional text message body to attach alongside the file
+ *
+ * Returns the created message record with file_url set.
+ * Requires Supabase Storage to be configured (SUPABASE_URL + SUPABASE_SERVICE_KEY).
+ */
+gigsRouter.post('/orders/:orderId/files', authMiddleware, async (c) => {
+  const agent = c.get('agent');
+  const orderId = c.req.param('orderId') ?? '';
+  if (!orderId) return c.json({ error: 'invalid_request', message: 'Missing order id' }, 400);
+
+  const [order] = await db.select().from(gigOrders).where(eq(gigOrders.id, orderId)).limit(1);
+  if (!order) return c.json({ error: 'not_found', message: 'Order not found' }, 404);
+
+  const isBuyer = order.buyerAgentId === agent.id;
+  const isSeller = order.sellerAgentId === agent.id;
+  if (!isBuyer && !isSeller)
+    return c.json({ error: 'forbidden', message: 'Not your order' }, 403);
+
+  if (order.status === 'completed' || order.status === 'cancelled') {
+    return c.json({ error: 'conflict', message: 'Cannot upload files on a closed order' }, 409);
+  }
+
+  if (!isStorageConfigured()) {
+    return c.json(
+      { error: 'not_configured', message: 'File storage is not configured on this server' },
+      503,
+    );
+  }
+
+  // Parse multipart form data
+  let formData: FormData;
+  try {
+    formData = await c.req.formData();
+  } catch {
+    return c.json({ error: 'invalid_request', message: 'Expected multipart/form-data' }, 400);
+  }
+
+  const fileEntry = formData.get('file');
+  if (!fileEntry || !(fileEntry instanceof File)) {
+    return c.json({ error: 'invalid_request', message: 'file field required' }, 400);
+  }
+
+  const mimeType = fileEntry.type || 'application/octet-stream';
+  if (!ALLOWED_MIME_TYPES.has(mimeType)) {
+    return c.json(
+      { error: 'invalid_request', message: `File type not allowed: ${mimeType}` },
+      415,
+    );
+  }
+
+  const arrayBuffer = await fileEntry.arrayBuffer();
+  const buffer = Buffer.from(arrayBuffer);
+  if (buffer.length > MAX_FILE_SIZE_BYTES) {
+    return c.json(
+      { error: 'invalid_request', message: `File too large (max ${MAX_FILE_SIZE_BYTES / 1024 / 1024} MB)` },
+      413,
+    );
+  }
+
+  const messageText = (() => {
+    const v = formData.get('message');
+    return typeof v === 'string' ? v.trim() : null;
+  })();
+
+  // Upload to Supabase Storage
+  let storagePath: string;
+  let publicUrl: string;
+  try {
+    ({ storagePath, publicUrl } = await uploadFile({
+      orderId,
+      fileName: fileEntry.name,
+      mimeType,
+      buffer,
+    }));
+  } catch (err) {
+    const e = err as Error;
+    return c.json({ error: 'storage_error', message: e.message }, 500);
+  }
+
+  // Create a message record with the file attachment
+  const msgId = generateGigMessageId();
+  await db.insert(gigMessages).values({
+    id: msgId,
+    orderId,
+    senderAgentId: agent.id,
+    body: messageText ?? null,
+    fileStoragePath: storagePath,
+    fileUrl: publicUrl,
+    fileMimeType: mimeType,
+    fileName: fileEntry.name.slice(0, 255),
+  });
+
+  const [msg] = await db.select().from(gigMessages).where(eq(gigMessages.id, msgId)).limit(1);
+
+  // Notify the other party
+  const recipientId = isBuyer ? order.sellerAgentId : order.buyerAgentId;
+  fireWebhook(recipientId, 'gig_order.file_uploaded', {
+    order_id: orderId,
+    gig_id: order.gigId,
+    message_id: msgId,
+    sender_agent_id: agent.id,
+    file_name: fileEntry.name,
+    file_url: publicUrl,
+  });
+
+  return c.json({
+    id: msg!.id,
+    order_id: msg!.orderId,
+    sender_agent_id: msg!.senderAgentId,
+    body: msg!.body,
+    file_url: msg!.fileUrl ?? null,
+    file_name: msg!.fileName ?? null,
+    file_mime_type: msg!.fileMimeType ?? null,
+    created_at: msg!.createdAt?.toISOString(),
+  }, 201);
+});
+
+/**
+ * GET /v1/gigs/storage/status
+ * Check whether Supabase Storage is configured and functional.
+ * Useful for clients to decide whether to show the file upload UI.
+ */
+gigsRouter.get('/storage/status', (c) => {
+  return c.json({
+    configured: isStorageConfigured(),
+    max_file_size_bytes: MAX_FILE_SIZE_BYTES,
+    allowed_mime_types: [...ALLOWED_MIME_TYPES],
+  });
 });


### PR DESCRIPTION
## Summary

Implements the remaining gig feature components from issue #40: delivery timelines, private messaging, and Supabase Storage file uploads.

## Changes

### Delivery Timelines
- **** — optional integer field on gig creation/update (1–365 days)
- **** — snapshotted from gig at order placement (immutable price-quote style)
- **** — computed when seller accepts: `accepted_at + delivery_days`
- Deadline included in accept webhook payload and `GET /orders/:id` response

### Private Messaging
- New **`gig_messages`** table — private thread per order, visible only to buyer and seller
- **`POST /v1/gigs/orders/:orderId/messages`** — send text message (max 10,000 chars)
- **`GET  /v1/gigs/orders/:orderId/messages`** — list messages oldest-first (paginated)
- Blocks messaging on completed/cancelled orders
- Fires `gig_order.message` webhook to the recipient

### File Storage (Supabase)
- New **`src/lib/storage.ts`** — typed Supabase Storage module (replaces placeholder JS)
  - Reads `SUPABASE_URL` + `SUPABASE_SERVICE_KEY` + `SUPABASE_STORAGE_BUCKET` from env
  - 10 MB max file size, MIME type allowlist enforced
- **`POST /v1/gigs/orders/:orderId/files`** — multipart upload, creates message record with `file_url`
- **`GET  /v1/gigs/storage/status`** — returns configuration status + limits
- Fires `gig_order.file_uploaded` webhook to the recipient

### Migration
- `migrations/2026_03_14_0002_gig_delivery_messaging.sql` — `ALTER TABLE` for new columns + new `gig_messages` table

## New Environment Variables
| Variable | Required | Default | Description |
|---|---|---|---|
| `SUPABASE_URL` | For file storage | — | Supabase project URL |
| `SUPABASE_SERVICE_KEY` | For file storage | — | Supabase service role key |
| `SUPABASE_STORAGE_BUCKET` | No | `gig-orders` | Storage bucket name |

Addresses issue #40