### PR TITLE
feat: add gig delivery timelines, private messaging & file attachments

### DIFF
--- a/drizzle/migrations/0005_gig_messaging_storage.sql
+++ b/drizzle/migrations/0005_gig_messaging_storage.sql
@@ -1,0 +1,44 @@
+-- Migration: Gig Messaging & File Storage
+-- Adds:
+--   1. delivery_days column to gigs table
+--   2. gig_messages table for private order messaging
+--   3. gig_attachments table for file storage metadata
+
+-- ---------------------------------------------------------------------------
+-- 1. Add delivery_days to gigs
+-- ---------------------------------------------------------------------------
+ALTER TABLE gigs
+  ADD COLUMN IF NOT EXISTS delivery_days INTEGER;
+
+-- ---------------------------------------------------------------------------
+-- 2. gig_messages — private messages between buyer and seller on an order
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS gig_messages (
+  id              VARCHAR(16) PRIMARY KEY,
+  order_id        VARCHAR(12) NOT NULL REFERENCES gig_orders(id),
+  sender_agent_id VARCHAR(12) NOT NULL REFERENCES agents(id),
+  content         TEXT        NOT NULL,
+  created_at      TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_gig_messages_order   ON gig_messages(order_id);
+CREATE INDEX IF NOT EXISTS idx_gig_messages_sender  ON gig_messages(sender_agent_id);
+CREATE INDEX IF NOT EXISTS idx_gig_messages_created ON gig_messages(created_at);
+
+-- ---------------------------------------------------------------------------
+-- 3. gig_attachments — file metadata for attachments stored in Supabase Storage
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS gig_attachments (
+  id                  VARCHAR(16)  PRIMARY KEY,
+  order_id            VARCHAR(12)  NOT NULL REFERENCES gig_orders(id),
+  uploader_agent_id   VARCHAR(12)  NOT NULL REFERENCES agents(id),
+  file_name           VARCHAR(255) NOT NULL,
+  mime_type           VARCHAR(100) NOT NULL,
+  file_size_bytes     INTEGER      NOT NULL,
+  storage_key         TEXT         NOT NULL,
+  public_url          TEXT,
+  created_at          TIMESTAMPTZ  DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_gig_attachments_order    ON gig_attachments(order_id);
+CREATE INDEX IF NOT EXISTS idx_gig_attachments_uploader ON gig_attachments(uploader_agent_id);

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -30,5 +30,19 @@
       "tag": "0003_x402_protocol",
       "breakpoints": true
     }
+    ,{
+      "idx": 4,
+      "version": "7",
+      "when": 1773700000000,
+      "tag": "0004_gig_orders",
+      "breakpoints": true
+    }
+    ,{
+      "idx": 5,
+      "version": "7",
+      "when": 1773800000000,
+      "tag": "0005_gig_messaging_storage",
+      "breakpoints": true
+    }
   ]
 }

--- a/src/db/schema/gig_attachments.ts
+++ b/src/db/schema/gig_attachments.ts
@@ -1,0 +1,37 @@
+import { pgTable, varchar, text, integer, timestamp, index } from 'drizzle-orm/pg-core';
+import { agents } from './agents.js';
+import { gigOrders } from './gig_orders.js';
+
+/**
+ * Files attached to a gig order (task requirements, deliverables, references).
+ * Stored in Supabase Storage bucket: gig-attachments.
+ */
+export const gigAttachments = pgTable('gig_attachments', {
+  id: varchar('id', { length: 16 }).primaryKey(),                         // "att_abc12345"
+
+  orderId: varchar('order_id', { length: 12 }).notNull()
+    .references(() => gigOrders.id),
+
+  uploaderAgentId: varchar('uploader_agent_id', { length: 12 }).notNull()
+    .references(() => agents.id),
+
+  /** Original filename as provided by the uploader */
+  fileName: varchar('file_name', { length: 255 }).notNull(),
+
+  /** MIME type of the uploaded file */
+  mimeType: varchar('mime_type', { length: 100 }).notNull(),
+
+  /** File size in bytes */
+  fileSizeBytes: integer('file_size_bytes').notNull(),
+
+  /** Storage path within the bucket (e.g. "orders/go_abc12345/att_xyz.pdf") */
+  storageKey: text('storage_key').notNull(),
+
+  /** Public URL for the file (set after upload) */
+  publicUrl: text('public_url'),
+
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
+}, (table) => [
+  index('idx_gig_attachments_order').on(table.orderId),
+  index('idx_gig_attachments_uploader').on(table.uploaderAgentId),
+]);

--- a/src/db/schema/gig_messages.ts
+++ b/src/db/schema/gig_messages.ts
@@ -1,0 +1,25 @@
+import { pgTable, varchar, text, timestamp, index } from 'drizzle-orm/pg-core';
+import { agents } from './agents.js';
+import { gigOrders } from './gig_orders.js';
+
+/**
+ * Private messages between buyer and seller on a gig order.
+ * Both parties (buyer and seller) on an order can read and send messages.
+ */
+export const gigMessages = pgTable('gig_messages', {
+  id: varchar('id', { length: 16 }).primaryKey(),                         // "msg_abc12345"
+
+  orderId: varchar('order_id', { length: 12 }).notNull()
+    .references(() => gigOrders.id),
+
+  senderAgentId: varchar('sender_agent_id', { length: 12 }).notNull()
+    .references(() => agents.id),
+
+  content: text('content').notNull(),
+
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
+}, (table) => [
+  index('idx_gig_messages_order').on(table.orderId),
+  index('idx_gig_messages_sender').on(table.senderAgentId),
+  index('idx_gig_messages_created').on(table.createdAt),
+]);

--- a/src/db/schema/gigs.ts
+++ b/src/db/schema/gigs.ts
@@ -10,6 +10,8 @@ export const gigs = pgTable('gigs', {
   category: varchar('category', { length: 30 }).notNull(),                // e.g., content, development, etc.
   pricePoints: decimal('price_points', { precision: 12, scale: 2 }),      // Points price
   priceUsdc: decimal('price_usdc', { precision: 12, scale: 6 }),          // USDC price
+  /** Estimated delivery time in calendar days (1–90) */
+  deliveryDays: integer('delivery_days'),
   status: varchar('status', { length: 20 }).default('open'),               // open | filled | canceled
   createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
   updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow(),

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -16,3 +16,5 @@ export { x402Payments } from './x402_payments.js';
 export { gigs } from './gigs.js';
 export { gigOrders, GIG_ORDER_TRANSITIONS } from './gig_orders.js';
 export type { GigOrderState } from './gig_orders.js';
+export { gigMessages } from './gig_messages.js';
+export { gigAttachments } from './gig_attachments.js';

--- a/src/lib/ids.ts
+++ b/src/lib/ids.ts
@@ -38,6 +38,14 @@ export function generateGigOrderId(): string {
   return shortId('go_', 8);
 }
 
+export function generateGigMessageId(): string {
+  return shortId('msg_', 8);
+}
+
+export function generateGigAttachmentId(): string {
+  return shortId('att_', 8);
+}
+
 /** Challenge code for Twitter verification (e.g. AXE-7f3a-9b2c) */
 export function generateChallengeCode(agentId: string): string {
   const suffix = agentId.replace('agt_', '').slice(0, 8);

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,0 +1,112 @@
+/**
+ * Supabase Storage integration for gig file attachments.
+ *
+ * Requires env vars:
+ *   SUPABASE_URL        — your Supabase project URL
+ *   SUPABASE_SERVICE_KEY — service role key (bypasses RLS)
+ *
+ * Bucket: gig-attachments (must be created in Supabase dashboard or via migration)
+ *
+ * File size limit: 10 MB per attachment.
+ * Allowed MIME types: image/*, application/pdf, text/plain, application/zip,
+ *   application/octet-stream, video/mp4.
+ */
+
+const BUCKET = 'gig-attachments';
+const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024; // 10 MB
+
+export const ALLOWED_MIME_TYPES = new Set([
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+  'image/svg+xml',
+  'application/pdf',
+  'text/plain',
+  'text/markdown',
+  'text/csv',
+  'application/zip',
+  'application/x-zip-compressed',
+  'application/json',
+  'application/octet-stream',
+  'video/mp4',
+]);
+
+export { MAX_FILE_SIZE_BYTES };
+
+function getSupabaseUrl(): string {
+  const url = process.env.SUPABASE_URL;
+  if (!url) throw new Error('SUPABASE_URL env var is not set');
+  return url.replace(/\/$/, '');
+}
+
+function getServiceKey(): string {
+  const key = process.env.SUPABASE_SERVICE_KEY;
+  if (!key) throw new Error('SUPABASE_SERVICE_KEY env var is not set');
+  return key;
+}
+
+/**
+ * Upload a file buffer to Supabase Storage.
+ *
+ * @param storageKey  Path within the bucket (e.g. "orders/go_abc/att_xyz.pdf")
+ * @param fileBuffer  Raw file data as Buffer
+ * @param mimeType    MIME type of the file
+ * @returns Public URL of the uploaded file
+ */
+export async function uploadToStorage(
+  storageKey: string,
+  fileBuffer: Buffer,
+  mimeType: string,
+): Promise<string> {
+  const base = getSupabaseUrl();
+  const key = getServiceKey();
+
+  const uploadUrl = `${base}/storage/v1/object/${BUCKET}/${storageKey}`;
+  const res = await fetch(uploadUrl, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${key}`,
+      'Content-Type': mimeType,
+      'x-upsert': 'false',
+    },
+    body: new Uint8Array(fileBuffer),
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Storage upload failed (${res.status}): ${body}`);
+  }
+
+  // Build public URL
+  return `${base}/storage/v1/object/public/${BUCKET}/${storageKey}`;
+}
+
+/**
+ * Delete a file from Supabase Storage.
+ *
+ * @param storageKey  Path within the bucket
+ */
+export async function deleteFromStorage(storageKey: string): Promise<void> {
+  const base = getSupabaseUrl();
+  const key = getServiceKey();
+
+  const deleteUrl = `${base}/storage/v1/object/${BUCKET}/${storageKey}`;
+  const res = await fetch(deleteUrl, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${key}` },
+  });
+
+  if (!res.ok && res.status !== 404) {
+    const body = await res.text();
+    throw new Error(`Storage delete failed (${res.status}): ${body}`);
+  }
+}
+
+/**
+ * Check whether storage is configured (env vars present).
+ * Used to return helpful errors when storage is not set up.
+ */
+export function isStorageConfigured(): boolean {
+  return !!(process.env.SUPABASE_URL && process.env.SUPABASE_SERVICE_KEY);
+}

--- a/src/routes/gigs.ts
+++ b/src/routes/gigs.ts
@@ -1,10 +1,10 @@
 import { Hono } from 'hono';
 import { eq, and, desc, sql } from 'drizzle-orm';
 import { db } from '../db/pool.js';
-import { gigs, gigOrders, agents, GIG_ORDER_TRANSITIONS } from '../db/schema/index.js';
+import { gigs, gigOrders, gigMessages, gigAttachments, agents, GIG_ORDER_TRANSITIONS } from '../db/schema/index.js';
 import type { GigOrderState } from '../db/schema/index.js';
 import { authMiddleware } from '../auth.js';
-import { generateGigId, generateGigOrderId } from '../lib/ids.js';
+import { generateGigId, generateGigOrderId, generateGigMessageId, generateGigAttachmentId } from '../lib/ids.js';
 import {
   escrowDeductForOrder,
   releaseEscrowForOrder,
@@ -12,6 +12,7 @@ import {
 } from '../lib/transfer.js';
 import { fireWebhook } from '../lib/webhooks.js';
 import { updateReputation, REPUTATION } from '../lib/reputation.js';
+import { uploadToStorage, isStorageConfigured, ALLOWED_MIME_TYPES, MAX_FILE_SIZE_BYTES } from '../lib/storage.js';
 import type { AgentRow } from '../db/schema/index.js';
 
 type AppVariables = { agent: AgentRow; agentId: string };
@@ -44,6 +45,7 @@ function formatGig(g: typeof gigs.$inferSelect) {
     category: g.category,
     price_points: g.pricePoints ? parseFloat(g.pricePoints) : null,
     price_usdc: g.priceUsdc ? parseFloat(g.priceUsdc) : null,
+    delivery_days: g.deliveryDays ?? null,
     status: g.status,
     created_at: g.createdAt?.toISOString(),
     updated_at: g.updatedAt?.toISOString(),
@@ -124,6 +126,12 @@ gigsRouter.post('/', authMiddleware, async (c) => {
       : typeof b.price_usdc === 'string'
         ? parseFloat(b.price_usdc)
         : null;
+  const deliveryDays =
+    typeof b.delivery_days === 'number'
+      ? Math.floor(b.delivery_days)
+      : typeof b.delivery_days === 'string'
+        ? parseInt(b.delivery_days, 10)
+        : null;
 
   if (!title || title.length > 200) {
     return c.json({ error: 'invalid_request', message: 'title required (max 200)' }, 400);
@@ -140,6 +148,9 @@ gigsRouter.post('/', authMiddleware, async (c) => {
       400,
     );
   }
+  if (deliveryDays !== null && (isNaN(deliveryDays) || deliveryDays < 1 || deliveryDays > 90)) {
+    return c.json({ error: 'invalid_request', message: 'delivery_days must be between 1 and 90' }, 400);
+  }
 
   const gigId = generateGigId();
   await db.insert(gigs).values({
@@ -150,6 +161,7 @@ gigsRouter.post('/', authMiddleware, async (c) => {
     category,
     pricePoints: pricePoints >= MIN_GIG_PRICE_POINTS ? pricePoints.toString() : null,
     priceUsdc: priceUsdc != null ? priceUsdc.toString() : null,
+    deliveryDays: deliveryDays ?? null,
     status: 'open',
   });
 
@@ -239,6 +251,15 @@ gigsRouter.patch('/:id', authMiddleware, async (c) => {
   if (typeof b.description === 'string') updates.description = b.description.slice(0, 5000);
   if (typeof b.price_points === 'number') updates.pricePoints = b.price_points.toString();
   if (typeof b.price_usdc === 'number') updates.priceUsdc = b.price_usdc.toString();
+  if (b.delivery_days !== undefined) {
+    const days = typeof b.delivery_days === 'number'
+      ? Math.floor(b.delivery_days)
+      : b.delivery_days === null ? null : parseInt(String(b.delivery_days), 10);
+    if (days !== null && (isNaN(days as number) || (days as number) < 1 || (days as number) > 90)) {
+      return c.json({ error: 'invalid_request', message: 'delivery_days must be between 1 and 90' }, 400);
+    }
+    updates.deliveryDays = days;
+  }
   if (Object.keys(updates).length === 0) return c.json(formatGig(gig), 200);
 
   await db.update(gigs).set({ ...updates, updatedAt: new Date() } as Record<string, unknown>).where(eq(gigs.id, id));
@@ -723,4 +744,287 @@ gigsRouter.get('/orders/my', authMiddleware, async (c) => {
     .offset(offset);
 
   return c.json({ orders: list.map(formatOrder), limit, offset });
+});
+
+// ---------------------------------------------------------------------------
+// Private Messaging (Order Threads)
+// ---------------------------------------------------------------------------
+
+/**
+ * Helper: assert caller is buyer or seller for the given order.
+ */
+async function getOrderForParty(orderId: string, agentId: string) {
+  const [order] = await db.select().from(gigOrders).where(eq(gigOrders.id, orderId)).limit(1);
+  if (!order) return { order: null, error: 'not_found' as const };
+  if (order.buyerAgentId !== agentId && order.sellerAgentId !== agentId)
+    return { order: null, error: 'forbidden' as const };
+  return { order, error: null };
+}
+
+/**
+ * POST /v1/gigs/orders/:orderId/messages
+ * Send a private message in an order thread.
+ * Both buyer and seller can participate.
+ */
+gigsRouter.post('/orders/:orderId/messages', authMiddleware, async (c) => {
+  const agent = c.get('agent');
+  const orderId = c.req.param('orderId') ?? '';
+  if (!orderId) return c.json({ error: 'invalid_request', message: 'Missing order id' }, 400);
+
+  const { order, error } = await getOrderForParty(orderId, agent.id);
+  if (error === 'not_found') return c.json({ error: 'not_found', message: 'Order not found' }, 404);
+  if (error === 'forbidden') return c.json({ error: 'forbidden', message: 'Not your order' }, 403);
+
+  // Cannot message on terminal orders (completed/cancelled) — but we allow it for disputes
+  if (order!.status === 'completed' || order!.status === 'cancelled') {
+    return c.json({ error: 'conflict', message: 'Cannot message on a closed order' }, 409);
+  }
+
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: 'invalid_request', message: 'Invalid JSON body' }, 400);
+  }
+
+  const b = body as Record<string, unknown>;
+  const content = typeof b.content === 'string' ? b.content.trim() : '';
+  if (!content || content.length > 4000) {
+    return c.json({ error: 'invalid_request', message: 'content required (max 4000 characters)' }, 400);
+  }
+
+  const msgId = generateGigMessageId();
+  await db.insert(gigMessages).values({
+    id: msgId,
+    orderId,
+    senderAgentId: agent.id,
+    content,
+  });
+
+  const [msg] = await db.select().from(gigMessages).where(eq(gigMessages.id, msgId)).limit(1);
+
+  // Notify the other party
+  const recipientId = order!.buyerAgentId === agent.id ? order!.sellerAgentId : order!.buyerAgentId;
+  fireWebhook(recipientId, 'gig_order.message', {
+    order_id: orderId,
+    gig_id: order!.gigId,
+    message_id: msgId,
+    sender_agent_id: agent.id,
+    content_preview: content.slice(0, 200),
+  });
+
+  return c.json({
+    id: msg!.id,
+    order_id: msg!.orderId,
+    sender_agent_id: msg!.senderAgentId,
+    content: msg!.content,
+    created_at: msg!.createdAt?.toISOString(),
+  }, 201);
+});
+
+/**
+ * GET /v1/gigs/orders/:orderId/messages
+ * List all messages in an order thread (buyer or seller only).
+ */
+gigsRouter.get('/orders/:orderId/messages', authMiddleware, async (c) => {
+  const agent = c.get('agent');
+  const orderId = c.req.param('orderId') ?? '';
+  if (!orderId) return c.json({ error: 'invalid_request', message: 'Missing order id' }, 400);
+
+  const { order, error } = await getOrderForParty(orderId, agent.id);
+  if (error === 'not_found') return c.json({ error: 'not_found', message: 'Order not found' }, 404);
+  if (error === 'forbidden') return c.json({ error: 'forbidden', message: 'Not your order' }, 403);
+
+  const limit = Math.min(parseInt(c.req.query('limit') ?? '100', 10) || 100, 200);
+  const offset = Math.max(0, parseInt(c.req.query('offset') ?? '0', 10) || 0);
+
+  const msgs = await db
+    .select()
+    .from(gigMessages)
+    .where(eq(gigMessages.orderId, orderId))
+    .orderBy(desc(gigMessages.createdAt))
+    .limit(limit)
+    .offset(offset);
+
+  return c.json({
+    order_id: orderId,
+    messages: msgs.map((m) => ({
+      id: m.id,
+      order_id: m.orderId,
+      sender_agent_id: m.senderAgentId,
+      content: m.content,
+      created_at: m.createdAt?.toISOString(),
+    })),
+    limit,
+    offset,
+  });
+});
+
+// ---------------------------------------------------------------------------
+// File Attachments
+// ---------------------------------------------------------------------------
+
+/**
+ * POST /v1/gigs/orders/:orderId/attachments
+ * Upload a file attachment for a gig order.
+ *
+ * Request: multipart/form-data
+ *   file     — the file data
+ *   filename — original filename (optional, falls back to Content-Disposition)
+ *
+ * Alternatively: JSON body with base64-encoded file:
+ *   { filename, mime_type, data_base64 }
+ *
+ * Requires SUPABASE_URL and SUPABASE_SERVICE_KEY env vars.
+ */
+gigsRouter.post('/orders/:orderId/attachments', authMiddleware, async (c) => {
+  const agent = c.get('agent');
+  const orderId = c.req.param('orderId') ?? '';
+  if (!orderId) return c.json({ error: 'invalid_request', message: 'Missing order id' }, 400);
+
+  if (!isStorageConfigured()) {
+    return c.json({ error: 'service_unavailable', message: 'File storage is not configured on this server' }, 503);
+  }
+
+  const { order, error } = await getOrderForParty(orderId, agent.id);
+  if (error === 'not_found') return c.json({ error: 'not_found', message: 'Order not found' }, 404);
+  if (error === 'forbidden') return c.json({ error: 'forbidden', message: 'Not your order' }, 403);
+
+  // Parse: accept JSON with base64 data or multipart/form-data
+  const contentType = c.req.header('content-type') ?? '';
+  let fileBuffer: Buffer;
+  let fileName: string;
+  let mimeType: string;
+
+  if (contentType.includes('multipart/form-data')) {
+    // Multipart upload
+    let formData: FormData;
+    try {
+      formData = await c.req.formData();
+    } catch {
+      return c.json({ error: 'invalid_request', message: 'Failed to parse multipart form data' }, 400);
+    }
+    const fileEntry = formData.get('file');
+    if (!fileEntry || !(fileEntry instanceof File)) {
+      return c.json({ error: 'invalid_request', message: 'file field required in multipart body' }, 400);
+    }
+    const nameEntry = formData.get('filename');
+    fileName = typeof nameEntry === 'string' ? nameEntry.trim() : fileEntry.name;
+    mimeType = fileEntry.type || 'application/octet-stream';
+    fileBuffer = Buffer.from(await fileEntry.arrayBuffer());
+  } else {
+    // JSON with base64 data
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ error: 'invalid_request', message: 'Invalid JSON body' }, 400);
+    }
+    const b = body as Record<string, unknown>;
+    fileName = typeof b.filename === 'string' ? b.filename.trim() : '';
+    mimeType = typeof b.mime_type === 'string' ? b.mime_type.trim() : 'application/octet-stream';
+    const dataBase64 = typeof b.data_base64 === 'string' ? b.data_base64 : '';
+    if (!fileName) return c.json({ error: 'invalid_request', message: 'filename required' }, 400);
+    if (!dataBase64) return c.json({ error: 'invalid_request', message: 'data_base64 required' }, 400);
+    try {
+      fileBuffer = Buffer.from(dataBase64, 'base64');
+    } catch {
+      return c.json({ error: 'invalid_request', message: 'data_base64 is not valid base64' }, 400);
+    }
+  }
+
+  if (!ALLOWED_MIME_TYPES.has(mimeType)) {
+    return c.json({
+      error: 'invalid_request',
+      message: `Unsupported file type: ${mimeType}. Allowed: images, PDF, text, CSV, JSON, ZIP, MP4`,
+    }, 415);
+  }
+
+  if (fileBuffer.length === 0) {
+    return c.json({ error: 'invalid_request', message: 'File is empty' }, 400);
+  }
+  if (fileBuffer.length > MAX_FILE_SIZE_BYTES) {
+    return c.json({ error: 'invalid_request', message: `File too large. Max size: ${MAX_FILE_SIZE_BYTES / (1024 * 1024)} MB` }, 413);
+  }
+
+  const attachId = generateGigAttachmentId();
+  // Sanitize filename for storage key
+  const safeFileName = fileName.replace(/[^a-zA-Z0-9._-]/g, '_').slice(0, 100);
+  const storageKey = `orders/${orderId}/${attachId}_${safeFileName}`;
+
+  let publicUrl: string;
+  try {
+    publicUrl = await uploadToStorage(storageKey, fileBuffer, mimeType);
+  } catch (err) {
+    console.error('Storage upload error:', err);
+    return c.json({ error: 'storage_error', message: 'File upload failed. Please try again.' }, 502);
+  }
+
+  await db.insert(gigAttachments).values({
+    id: attachId,
+    orderId,
+    uploaderAgentId: agent.id,
+    fileName,
+    mimeType,
+    fileSizeBytes: fileBuffer.length,
+    storageKey,
+    publicUrl,
+  });
+
+  const [att] = await db.select().from(gigAttachments).where(eq(gigAttachments.id, attachId)).limit(1);
+
+  // Notify the other party
+  const recipientId = order!.buyerAgentId === agent.id ? order!.sellerAgentId : order!.buyerAgentId;
+  fireWebhook(recipientId, 'gig_order.attachment', {
+    order_id: orderId,
+    gig_id: order!.gigId,
+    attachment_id: attachId,
+    uploader_agent_id: agent.id,
+    file_name: fileName,
+  });
+
+  return c.json({
+    id: att!.id,
+    order_id: att!.orderId,
+    uploader_agent_id: att!.uploaderAgentId,
+    file_name: att!.fileName,
+    mime_type: att!.mimeType,
+    file_size_bytes: att!.fileSizeBytes,
+    public_url: att!.publicUrl,
+    created_at: att!.createdAt?.toISOString(),
+  }, 201);
+});
+
+/**
+ * GET /v1/gigs/orders/:orderId/attachments
+ * List all file attachments for a gig order (buyer or seller only).
+ */
+gigsRouter.get('/orders/:orderId/attachments', authMiddleware, async (c) => {
+  const agent = c.get('agent');
+  const orderId = c.req.param('orderId') ?? '';
+  if (!orderId) return c.json({ error: 'invalid_request', message: 'Missing order id' }, 400);
+
+  const { error } = await getOrderForParty(orderId, agent.id);
+  if (error === 'not_found') return c.json({ error: 'not_found', message: 'Order not found' }, 404);
+  if (error === 'forbidden') return c.json({ error: 'forbidden', message: 'Not your order' }, 403);
+
+  const attachments = await db
+    .select()
+    .from(gigAttachments)
+    .where(eq(gigAttachments.orderId, orderId))
+    .orderBy(desc(gigAttachments.createdAt));
+
+  return c.json({
+    order_id: orderId,
+    attachments: attachments.map((a) => ({
+      id: a.id,
+      order_id: a.orderId,
+      uploader_agent_id: a.uploaderAgentId,
+      file_name: a.fileName,
+      mime_type: a.mimeType,
+      file_size_bytes: a.fileSizeBytes,
+      public_url: a.publicUrl,
+      created_at: a.createdAt?.toISOString(),
+    })),
+  });
 });


### PR DESCRIPTION
## Summary

Extends the existing Gig feature with the capabilities specified in issue #40:

### 1. Delivery Timelines
- Added `delivery_days` field (1–90 days) to the `gigs` table
- Exposed in all CRUD endpoints: `POST /v1/gigs`, `PATCH /v1/gigs/:id`, list/get responses
- Validation: must be integer 1–90

### 2. Private Messaging (Order Threads)
- New `gig_messages` table for buyer ↔ seller communication on orders
- **`POST /v1/gigs/orders/:orderId/messages`** — send a message (max 4000 chars)
- **`GET /v1/gigs/orders/:orderId/messages`** — list thread (paginated, newest-first)
- Restricted to order parties (buyer/seller); blocked on completed/cancelled orders
- Fires `gig_order.message` webhook to notify the other party

### 3. File Attachments (Storage)
- New `gig_attachments` table storing file metadata
- New `src/lib/storage.ts` — Supabase Storage integration using `SUPABASE_URL` + `SUPABASE_SERVICE_KEY` env vars
- **`POST /v1/gigs/orders/:orderId/attachments`** — upload via multipart/form-data OR JSON with base64 data
- **`GET /v1/gigs/orders/:orderId/attachments`** — list all attachments for an order
- Max 10 MB per file; allowed types: images, PDF, text, CSV, JSON, ZIP, MP4
- Returns 503 with helpful message if storage env vars not configured
- Fires `gig_order.attachment` webhook to notify the other party

### 4. Database Migration
- `drizzle/migrations/0005_gig_messaging_storage.sql`
- Adds `delivery_days` column to `gigs`
- Creates `gig_messages` and `gig_attachments` tables with indexes

Addresses issue #40