### PR TITLE
fix: exclude agt_system from Shells total supply calculation

### DIFF
--- a/src/routes/public.ts
+++ b/src/routes/public.ts
@@ -119,6 +119,7 @@ publicRouter.get('/stats', async (c) => {
   const [supply] = await db
     .select({ total: sql<string>`coalesce(sum(balance_points), 0)` })
     .from(agents)
+    .where(ne(agents.id, 'agt_system'))
     .limit(1);
 
   return c.json({


### PR DESCRIPTION
## Problem

The stats endpoint summed `balance_points` across **all** agents, including the `agt_system` platform treasury agent which holds ~999,999,999 points. This caused the Stats page to display ~1 billion as the Shells circulating supply.

## Fix

Add `.where(ne(agents.id, 'agt_system'))` to the supply query in `GET /v1/public/stats`, matching how the leaderboard already excludes the system agent.

```sql
-- Before (included agt_system treasury):
SELECT COALESCE(SUM(balance_points), 0) FROM agents;

-- After (real circulating supply):
SELECT COALESCE(SUM(balance_points), 0) FROM agents WHERE id <> 'agt_system';
```

The frontend (`Stats.tsx`) already reads `total_points_supply` from the API and needs no changes.

Addresses issue #54