### PR TITLE
feat: fix stats & feed — prices, x402 recording, Shells spent, network split

### DIFF
--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -41,11 +41,23 @@ export interface LeaderboardEntry {
   tasks_created: number;
 }
 
-export interface X402Stats {
+export interface X402NetworkStats {
   usdc_tasks: number;
   total_usdc_volume: number;
   unique_payers: number;
   unique_recipients: number;
+}
+
+export interface X402Stats {
+  networks: Record<string, X402NetworkStats>;
+  total: X402NetworkStats;
+}
+
+export interface TasksByStatus {
+  open: number;
+  in_progress: number;
+  completed: number;
+  cancelled: number;
 }
 
 export interface PlatformStats {
@@ -54,6 +66,10 @@ export interface PlatformStats {
   tasks: number;
   tasks_completed: number;
   total_points_supply: number;
+  shells_spent: number;
+  tasks_by_status: TasksByStatus;
+  avg_price_points: number;
+  avg_price_usdc: number;
   x402?: X402Stats;
 }
 

--- a/frontend/src/pages/Stats.tsx
+++ b/frontend/src/pages/Stats.tsx
@@ -1,5 +1,5 @@
 import { usePlatformStats } from '@/api/queries';
-import { Users, CheckCircle, ListTodo, Award, Coins, ExternalLink, Wallet, CircleDollarSign } from 'lucide-react';
+import { Users, CheckCircle, ListTodo, Award, Coins, ExternalLink, Wallet, CircleDollarSign, TrendingDown } from 'lucide-react';
 import { Skeleton } from '@/components/ui/skeleton';
 
 interface StatCardProps {
@@ -22,15 +22,23 @@ function StatCard({ label, value, icon, description }: StatCardProps) {
   );
 }
 
-function getNetworkLabel(): string {
-  const network = import.meta.env.VITE_BASE_NETWORK as string | undefined;
+function getNetworkLabel(network: string): string {
   if (network === 'eip155:8453') return 'Base Mainnet';
-  return 'Base Sepolia (testnet)';
+  if (network === 'eip155:84532') return 'Base Sepolia (testnet)';
+  return network;
+}
+
+function getEnvNetworkLabel(): string {
+  const network = import.meta.env.VITE_BASE_NETWORK as string | undefined;
+  return getNetworkLabel(network ?? 'eip155:84532');
 }
 
 export default function Stats() {
   const { data, isLoading } = usePlatformStats();
-  const networkLabel = getNetworkLabel();
+  const envNetworkLabel = getEnvNetworkLabel();
+
+  const networkEntries = data?.x402?.networks ? Object.entries(data.x402.networks) : [];
+  const hasMultipleNetworks = networkEntries.length > 1;
 
   return (
     <div className="container py-8">
@@ -40,7 +48,7 @@ export default function Stats() {
       {isLoading && (
         <div className="space-y-8">
           <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-            {Array.from({ length: 5 }).map((_, i) => (
+            {Array.from({ length: 6 }).map((_, i) => (
               <Skeleton key={i} className="h-28 rounded-lg" />
             ))}
           </div>
@@ -86,6 +94,12 @@ export default function Stats() {
               icon={<Coins size={18} />}
               description="Circulating Shells balance"
             />
+            <StatCard
+              label="Shells Spent 🐚"
+              value={(data.shells_spent ?? 0).toFixed(0)}
+              icon={<TrendingDown size={18} />}
+              description="Total Shells paid for tasks"
+            />
             {data.tasks > 0 && (
               <div className="rounded-lg border bg-card p-6">
                 <div className="flex items-center gap-3 mb-3 text-muted-foreground">
@@ -102,37 +116,138 @@ export default function Stats() {
             )}
           </div>
 
+          {/* Tasks by Status */}
+          {data.tasks_by_status && (
+            <div>
+              <h2 className="text-lg font-semibold mb-4">Tasks by Status</h2>
+              <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+                <StatCard
+                  label="Open"
+                  value={data.tasks_by_status.open ?? 0}
+                  icon={<ListTodo size={18} />}
+                  description="Awaiting bids"
+                />
+                <StatCard
+                  label="In Progress"
+                  value={data.tasks_by_status.in_progress ?? 0}
+                  icon={<TrendingDown size={18} />}
+                  description="Being worked on"
+                />
+                <StatCard
+                  label="Completed"
+                  value={data.tasks_by_status.completed ?? 0}
+                  icon={<CheckCircle size={18} />}
+                  description="Successfully finished"
+                />
+                <StatCard
+                  label="Cancelled"
+                  value={data.tasks_by_status.cancelled ?? 0}
+                  icon={<ListTodo size={18} />}
+                  description="Cancelled tasks"
+                />
+              </div>
+            </div>
+          )}
+
+          {/* Average Prices */}
+          {(data.avg_price_points !== undefined || data.avg_price_usdc !== undefined) && (
+            <div>
+              <h2 className="text-lg font-semibold mb-4">Average Task Prices</h2>
+              <div className="grid gap-4 sm:grid-cols-2">
+                <StatCard
+                  label="Avg Price (Shells 🐚)"
+                  value={(data.avg_price_points ?? 0).toFixed(1)}
+                  icon={<Coins size={18} />}
+                  description="Average price for Shells-based tasks"
+                />
+                <StatCard
+                  label="Avg Price (USDC)"
+                  value={`$${(data.avg_price_usdc ?? 0).toFixed(2)}`}
+                  icon={<CircleDollarSign size={18} />}
+                  description="Average price for USDC-based tasks"
+                />
+              </div>
+            </div>
+          )}
+
           {/* x402 USDC Payment Stats */}
           <div>
             <div className="flex items-center gap-3 mb-4">
               <h2 className="text-lg font-semibold">x402 USDC Payments</h2>
               <span className="flex items-center gap-1.5 text-xs font-medium bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300 px-2.5 py-1 rounded-full">
                 <ExternalLink size={11} />
-                {networkLabel}
+                {envNetworkLabel}
               </span>
             </div>
+
+            {/* Per-network breakdown (shown when data from multiple networks exists) */}
+            {hasMultipleNetworks && (
+              <div className="space-y-6 mb-6">
+                {networkEntries.map(([network, stats]) => (
+                  <div key={network}>
+                    <div className="flex items-center gap-2 mb-3">
+                      <span className="text-sm font-medium text-muted-foreground">
+                        {getNetworkLabel(network)}
+                      </span>
+                      <span className="text-xs bg-muted px-2 py-0.5 rounded font-mono">{network}</span>
+                    </div>
+                    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+                      <StatCard
+                        label="USDC Tasks"
+                        value={stats.usdc_tasks}
+                        icon={<CircleDollarSign size={18} />}
+                        description="Tasks paid via USDC"
+                      />
+                      <StatCard
+                        label="USDC Volume"
+                        value={`$${stats.total_usdc_volume.toFixed(2)}`}
+                        icon={<Coins size={18} />}
+                        description="Escrow + payout transactions"
+                      />
+                      <StatCard
+                        label="Unique Payers"
+                        value={stats.unique_payers}
+                        icon={<Wallet size={18} />}
+                        description="Distinct payer wallets"
+                      />
+                      <StatCard
+                        label="Unique Recipients"
+                        value={stats.unique_recipients}
+                        icon={<Users size={18} />}
+                        description="Distinct recipient wallets"
+                      />
+                    </div>
+                  </div>
+                ))}
+                <div>
+                  <span className="text-sm font-medium text-muted-foreground">All Networks (Total)</span>
+                </div>
+              </div>
+            )}
+
+            {/* Total stats (always shown) */}
             <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
               <StatCard
                 label="USDC Tasks"
-                value={data.x402?.usdc_tasks ?? 0}
+                value={data.x402?.total?.usdc_tasks ?? 0}
                 icon={<CircleDollarSign size={18} />}
                 description="Tasks paid via USDC"
               />
               <StatCard
                 label="Total USDC Volume"
-                value={`$${(data.x402?.total_usdc_volume ?? 0).toFixed(2)}`}
+                value={`$${(data.x402?.total?.total_usdc_volume ?? 0).toFixed(2)}`}
                 icon={<Coins size={18} />}
                 description="Escrow + payout transactions"
               />
               <StatCard
                 label="Unique Payers"
-                value={data.x402?.unique_payers ?? 0}
+                value={data.x402?.total?.unique_payers ?? 0}
                 icon={<Wallet size={18} />}
                 description="Distinct payer wallets"
               />
               <StatCard
                 label="Unique Recipients"
-                value={data.x402?.unique_recipients ?? 0}
+                value={data.x402?.total?.unique_recipients ?? 0}
                 icon={<Users size={18} />}
                 description="Distinct recipient wallets"
               />

--- a/src/routes/public.ts
+++ b/src/routes/public.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import { eq, ne, desc, sql, and, inArray } from 'drizzle-orm';
 import { db } from '../db/pool.js';
-import { agents, tasks, submissions, x402Payments } from '../db/schema/index.js';
+import { agents, tasks, submissions, x402Payments, transactions } from '../db/schema/index.js';
 
 export const publicRouter = new Hono();
 
@@ -50,6 +50,9 @@ publicRouter.get('/feed', async (c) => {
         category: t.category,
         title: t.title,
         price_points: t.pricePoints,
+        price_usdc: t.priceUsdc ? parseFloat(t.priceUsdc) : null,
+        payment_mode: t.paymentMode,
+        escrow_tx_hash: t.escrowTxHash ?? null,
         status: t.status,
         completed_at: t.updatedAt?.toISOString(),
         result_url: s?.resultUrl ?? null,
@@ -122,7 +125,44 @@ publicRouter.get('/stats', async (c) => {
     .where(ne(agents.id, 'agt_system'))
     .limit(1);
 
-  // x402 USDC payment stats
+  // Shells spent (sum of 'payment' type transactions)
+  const [shellsSpent] = await db
+    .select({ total: sql<string>`coalesce(sum(amount::numeric), 0)` })
+    .from(transactions)
+    .where(eq(transactions.type, 'payment'))
+    .limit(1);
+
+  // Tasks by status
+  const tasksByStatusRaw = await db
+    .select({
+      status: tasks.status,
+      count: sql<number>`count(*)`,
+    })
+    .from(tasks)
+    .groupBy(tasks.status);
+
+  const tasksByStatus: Record<string, number> = {
+    open: 0,
+    in_progress: 0,
+    completed: 0,
+    cancelled: 0,
+  };
+  for (const row of tasksByStatusRaw) {
+    if (row.status && row.status in tasksByStatus) {
+      tasksByStatus[row.status] = Number(row.count);
+    }
+  }
+
+  // Average task price (points and USDC)
+  const [avgPricesRaw] = await db
+    .select({
+      avg_points: sql<string>`coalesce(avg(price_points::numeric) filter (where payment_mode = 'points'), 0)`,
+      avg_usdc: sql<string>`coalesce(avg(price_usdc::numeric) filter (where payment_mode = 'usdc'), 0)`,
+    })
+    .from(tasks)
+    .limit(1);
+
+  // x402 USDC payment stats — total
   const [usdcTasksCount] = await db
     .select({ n: sql<number>`count(*)` })
     .from(tasks)
@@ -145,17 +185,51 @@ publicRouter.get('/stats', async (c) => {
     .from(x402Payments)
     .limit(1);
 
+  // x402 USDC payment stats — per network
+  const networkStatsRaw = await db
+    .select({
+      network: x402Payments.network,
+      usdc_tasks: sql<number>`count(distinct task_id)`,
+      total_usdc_volume: sql<string>`coalesce(sum(case when payment_type in ('escrow', 'payout') then amount_usdc::numeric else 0 end), 0)`,
+      unique_payers: sql<number>`count(distinct payer_address)`,
+      unique_recipients: sql<number>`count(distinct recipient_address)`,
+    })
+    .from(x402Payments)
+    .groupBy(x402Payments.network);
+
+  const networks: Record<string, {
+    usdc_tasks: number;
+    total_usdc_volume: number;
+    unique_payers: number;
+    unique_recipients: number;
+  }> = {};
+  for (const row of networkStatsRaw) {
+    networks[row.network] = {
+      usdc_tasks: Number(row.usdc_tasks),
+      total_usdc_volume: parseFloat(String(row.total_usdc_volume ?? '0')),
+      unique_payers: Number(row.unique_payers),
+      unique_recipients: Number(row.unique_recipients),
+    };
+  }
+
   return c.json({
     agents: Number((agentsCount as { n: number })?.n ?? 0),
     verified_agents: Number((verifiedCount as { n: number })?.n ?? 0),
     tasks: Number((tasksCount as { n: number })?.n ?? 0),
     tasks_completed: Number((completedCount as { n: number })?.n ?? 0),
     total_points_supply: parseFloat(String((supply as { total: string })?.total ?? '0')),
+    shells_spent: parseFloat(String((shellsSpent as { total: string })?.total ?? '0')),
+    tasks_by_status: tasksByStatus,
+    avg_price_points: parseFloat(String((avgPricesRaw as { avg_points: string; avg_usdc: string })?.avg_points ?? '0')),
+    avg_price_usdc: parseFloat(String((avgPricesRaw as { avg_points: string; avg_usdc: string })?.avg_usdc ?? '0')),
     x402: {
-      usdc_tasks: Number((usdcTasksCount as { n: number })?.n ?? 0),
-      total_usdc_volume: parseFloat(String((usdcVolume as { total: string })?.total ?? '0')),
-      unique_payers: Number((uniquePayers as { n: number })?.n ?? 0),
-      unique_recipients: Number((uniqueRecipients as { n: number })?.n ?? 0),
+      networks,
+      total: {
+        usdc_tasks: Number((usdcTasksCount as { n: number })?.n ?? 0),
+        total_usdc_volume: parseFloat(String((usdcVolume as { total: string })?.total ?? '0')),
+        unique_payers: Number((uniquePayers as { n: number })?.n ?? 0),
+        unique_recipients: Number((uniqueRecipients as { n: number })?.n ?? 0),
+      },
     },
   });
 });

--- a/src/routes/x402.ts
+++ b/src/routes/x402.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import { eq, sql } from 'drizzle-orm';
 import { db } from '../db/pool.js';
-import { agents, tasks, type AgentRow } from '../db/schema/index.js';
+import { agents, tasks, x402Payments, type AgentRow } from '../db/schema/index.js';
 import { authMiddleware } from '../auth.js';
 import { generateTaskId } from '../lib/ids.js';
 import { rateLimitMiddleware } from '../middleware/rateLimit.js';
@@ -125,14 +125,16 @@ x402Router.post('/tasks', rateLimitMiddleware, async (c) => {
   const deadline = typeof b.deadline === 'string' ? new Date(b.deadline) : null;
   const taskId = generateTaskId();
 
-  // Attempt to extract escrow tx hash from the payment header if available
+  // Attempt to extract escrow tx hash and payer address from the payment header if available
   const paymentHeader = c.req.header('x-payment') ?? c.req.header('payment-signature');
   let escrowTxHash: string | null = null;
+  let payerAddress: string | null = null;
   if (paymentHeader) {
     try {
       const decoded = Buffer.from(paymentHeader, 'base64').toString('utf-8');
       const parsed = JSON.parse(decoded) as Record<string, unknown>;
       escrowTxHash = (parsed?.transaction as string) ?? (parsed?.tx_hash as string) ?? null;
+      payerAddress = (parsed?.from as string) ?? (parsed?.payer as string) ?? (parsed?.sender as string) ?? null;
     } catch {
       // non-critical, best-effort
     }
@@ -159,6 +161,17 @@ x402Router.post('/tasks', rateLimitMiddleware, async (c) => {
   await db.update(agents)
     .set({ tasksCreated: sql`tasks_created + 1`, updatedAt: sql`NOW()` })
     .where(eq(agents.id, agent.id));
+
+  // Record the x402 payment for on-chain tracking
+  await db.insert(x402Payments).values({
+    taskId,
+    payerAddress: payerAddress ?? 'unknown',
+    recipientAddress: PLATFORM_EVM_ADDRESS,
+    amountUsdc: priceUsdc.toFixed(6),
+    txHash: escrowTxHash ?? `pending-${taskId}`,
+    network: BASE_NETWORK,
+    paymentType: 'escrow',
+  });
 
   fireWebhook(agent.id, 'task.created', {
     task_id: taskId,


### PR DESCRIPTION
## Summary

Addresses issue #59 — multiple data gaps in the web interface.

### Changes

**1. Feed API ()**
- Added `price_usdc`, `payment_mode`, `escrow_tx_hash` to `GET /v1/public/feed` response

**2. x402 payments recording ()**
- Added `db.insert(x402_payments)` after task creation in `POST /v1/x402/tasks`
- Extracts payer address and tx hash from the payment header (best-effort)
- Falls back to `'unknown'` for payer and `'pending-{taskId}'` for tx hash if not parseable

**3. Stats: Shells spent ()**
- Added `shells_spent` field: `SUM(amount) WHERE type = 'payment'` from transactions table

**4. Stats: x402 testnet/mainnet split**
- x402 stats now include per-network breakdown (`networks` object keyed by network id)
- Plus a `total` object summing across all networks
- Frontend shows per-network sections when multiple networks exist

**5. Stats: tasks_by_status**
- Added `tasks_by_status: { open, in_progress, completed, cancelled }` grouped from DB

**6. Stats: average task prices**
- Added `avg_price_points` and `avg_price_usdc` using conditional aggregates

**Frontend (, )**
- Updated TypeScript types: `X402NetworkStats`, `X402Stats`, `TasksByStatus`, `PlatformStats`
- Stats page shows: Shells Spent card, Tasks by Status grid, Avg Prices section, per-network x402 breakdown