### PR TITLE
feat: show prices everywhere + 3-currency system (Shells / USDC Sepolia / USDC Mainnet)

### DIFF
--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -12,11 +12,14 @@ export interface Task {
   description?: string;
   acceptance_criteria?: string[];
   price_points: number | null;
+  price_usdc?: number | null;
   status: string;
   deadline?: string | null;
   created_at?: string;
   payment_mode?: string | null;
   escrow_tx_hash?: string | null;
+  /** EIP-155 network id, e.g. 'eip155:8453' (mainnet) or 'eip155:84532' (sepolia). null for shells tasks. */
+  network?: string | null;
 }
 
 export interface Agent {
@@ -60,6 +63,24 @@ export interface TasksByStatus {
   cancelled: number;
 }
 
+export interface ShellsCurrencyStats {
+  total_supply: number;
+  total_spent: number;
+  avg_task_price: number;
+}
+
+export interface UsdcCurrencyStats {
+  total_volume: number;
+  task_count: number;
+  unique_payers: number;
+}
+
+export interface CurrenciesStats {
+  shells: ShellsCurrencyStats;
+  usdc_sepolia: UsdcCurrencyStats;
+  usdc_mainnet: UsdcCurrencyStats;
+}
+
 export interface PlatformStats {
   agents: number;
   verified_agents: number;
@@ -70,6 +91,7 @@ export interface PlatformStats {
   tasks_by_status: TasksByStatus;
   avg_price_points: number;
   avg_price_usdc: number;
+  currencies?: CurrenciesStats;
   x402?: X402Stats;
 }
 
@@ -190,7 +212,7 @@ export function usePlatformStats() {
 export function usePublicFeed(limit = 20, offset = 0) {
   return useQuery({
     queryKey: ['public-feed', limit, offset],
-    queryFn: () => apiFetch<{ tasks: unknown[] }>(`/v1/public/feed?limit=${limit}&offset=${offset}`),
+    queryFn: () => apiFetch<{ tasks: Task[] }>(`/v1/public/feed?limit=${limit}&offset=${offset}`),
   });
 }
 

--- a/frontend/src/components/shared/TaskCard.tsx
+++ b/frontend/src/components/shared/TaskCard.tsx
@@ -7,20 +7,60 @@ interface TaskCardProps {
   task: Task;
 }
 
-function getExplorerUrl(txHash: string): string {
-  const network = import.meta.env.VITE_BASE_NETWORK as string | undefined;
-  const base = network === 'eip155:8453'
+const NETWORK_SEPOLIA = 'eip155:84532';
+const NETWORK_MAINNET = 'eip155:8453';
+
+function getExplorerUrl(txHash: string, network: string | null | undefined): string {
+  const base = network === NETWORK_MAINNET
     ? 'https://basescan.org/tx/'
     : 'https://sepolia.basescan.org/tx/';
   return `${base}${txHash}`;
 }
 
-export default function TaskCard({ task }: TaskCardProps) {
-  const isUsdc = task.payment_mode === 'usdc';
-  const explorerUrl = isUsdc && task.escrow_tx_hash
-    ? getExplorerUrl(task.escrow_tx_hash)
-    : null;
+function PriceBadge({ task }: { task: Task }) {
+  const { payment_mode, price_points, price_usdc, network, escrow_tx_hash } = task;
 
+  if (payment_mode === 'usdc' && price_usdc != null) {
+    const isMainnet = network === NETWORK_MAINNET;
+    const isSepolia = network === NETWORK_SEPOLIA;
+    const explorerUrl = escrow_tx_hash ? getExplorerUrl(escrow_tx_hash, network) : null;
+    const label = isMainnet
+      ? `$${price_usdc} USDC`
+      : `$${price_usdc} USDC${isSepolia ? ' (testnet)' : ''}`;
+
+    return (
+      <span className="flex items-center gap-1">
+        <span className="text-xs font-semibold bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300 px-2 py-0.5 rounded">
+          {label}
+        </span>
+        {explorerUrl && (
+          <a
+            href={explorerUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={(e) => e.stopPropagation()}
+            className="text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-200"
+            title={isMainnet ? 'View on BaseScan' : 'View on BaseScan Sepolia'}
+          >
+            <ExternalLink size={11} />
+          </a>
+        )}
+      </span>
+    );
+  }
+
+  if (price_points != null) {
+    return (
+      <span className="flex items-center gap-1">
+        {price_points} 🐚
+      </span>
+    );
+  }
+
+  return null;
+}
+
+export default function TaskCard({ task }: TaskCardProps) {
   return (
     <Link
       to={`/explore/${task.id}`}
@@ -29,11 +69,6 @@ export default function TaskCard({ task }: TaskCardProps) {
       <div className="flex items-start justify-between gap-2 mb-2">
         <h3 className="font-medium text-sm leading-snug line-clamp-2">{task.title}</h3>
         <div className="flex items-center gap-1.5 shrink-0">
-          {isUsdc && (
-            <span className="text-xs font-semibold bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300 px-2 py-0.5 rounded">
-              USDC
-            </span>
-          )}
           <StatusBadge status={task.status} />
         </div>
       </div>
@@ -42,25 +77,9 @@ export default function TaskCard({ task }: TaskCardProps) {
       </p>
       <div className="flex items-center gap-3 text-xs text-muted-foreground">
         <span className="bg-muted px-2 py-0.5 rounded capitalize">{task.category}</span>
-        {task.price_points != null && (
-          <span className="flex items-center gap-1">
-            {task.price_points} 🐚
-          </span>
-        )}
-        {explorerUrl && (
-          <a
-            href={explorerUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            onClick={(e) => e.stopPropagation()}
-            className="flex items-center gap-1 text-blue-600 dark:text-blue-400 hover:underline ml-auto"
-          >
-            <ExternalLink size={11} />
-            Tx
-          </a>
-        )}
+        <PriceBadge task={task} />
         {task.created_at && (
-          <span className={`flex items-center gap-1 ${explorerUrl ? '' : 'ml-auto'}`}>
+          <span className="flex items-center gap-1 ml-auto">
             <Clock size={11} />
             {new Date(task.created_at).toLocaleDateString()}
           </span>

--- a/frontend/src/pages/Stats.tsx
+++ b/frontend/src/pages/Stats.tsx
@@ -1,5 +1,5 @@
 import { usePlatformStats } from '@/api/queries';
-import { Users, CheckCircle, ListTodo, Award, Coins, ExternalLink, Wallet, CircleDollarSign, TrendingDown } from 'lucide-react';
+import { Users, CheckCircle, ListTodo, Award, Coins, Wallet, CircleDollarSign, TrendingDown } from 'lucide-react';
 import { Skeleton } from '@/components/ui/skeleton';
 
 interface StatCardProps {
@@ -22,23 +22,30 @@ function StatCard({ label, value, icon, description }: StatCardProps) {
   );
 }
 
-function getNetworkLabel(network: string): string {
-  if (network === 'eip155:8453') return 'Base Mainnet';
-  if (network === 'eip155:84532') return 'Base Sepolia (testnet)';
-  return network;
+interface CurrencySectionProps {
+  title: string;
+  emoji?: string;
+  badge?: React.ReactNode;
+  children: React.ReactNode;
 }
 
-function getEnvNetworkLabel(): string {
-  const network = import.meta.env.VITE_BASE_NETWORK as string | undefined;
-  return getNetworkLabel(network ?? 'eip155:84532');
+function CurrencySection({ title, emoji, badge, children }: CurrencySectionProps) {
+  return (
+    <div className="rounded-xl border bg-muted/30 p-5">
+      <div className="flex items-center gap-2 mb-4">
+        <h3 className="text-base font-semibold">
+          {emoji && <span className="mr-1">{emoji}</span>}
+          {title}
+        </h3>
+        {badge}
+      </div>
+      {children}
+    </div>
+  );
 }
 
 export default function Stats() {
   const { data, isLoading } = usePlatformStats();
-  const envNetworkLabel = getEnvNetworkLabel();
-
-  const networkEntries = data?.x402?.networks ? Object.entries(data.x402.networks) : [];
-  const hasMultipleNetworks = networkEntries.length > 1;
 
   return (
     <div className="container py-8">
@@ -52,9 +59,9 @@ export default function Stats() {
               <Skeleton key={i} className="h-28 rounded-lg" />
             ))}
           </div>
-          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-            {Array.from({ length: 4 }).map((_, i) => (
-              <Skeleton key={i} className="h-28 rounded-lg" />
+          <div className="grid gap-4 sm:grid-cols-3">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <Skeleton key={i} className="h-48 rounded-xl" />
             ))}
           </div>
         </div>
@@ -87,18 +94,6 @@ export default function Stats() {
               value={data.tasks_completed}
               icon={<CheckCircle size={18} />}
               description="Successfully completed"
-            />
-            <StatCard
-              label="Total Shells Supply 🐚"
-              value={data.total_points_supply.toFixed(0)}
-              icon={<Coins size={18} />}
-              description="Circulating Shells balance"
-            />
-            <StatCard
-              label="Shells Spent 🐚"
-              value={(data.shells_spent ?? 0).toFixed(0)}
-              icon={<TrendingDown size={18} />}
-              description="Total Shells paid for tasks"
             />
             {data.tasks > 0 && (
               <div className="rounded-lg border bg-card p-6">
@@ -149,108 +144,103 @@ export default function Stats() {
             </div>
           )}
 
-          {/* Average Prices */}
-          {(data.avg_price_points !== undefined || data.avg_price_usdc !== undefined) && (
-            <div>
-              <h2 className="text-lg font-semibold mb-4">Average Task Prices</h2>
-              <div className="grid gap-4 sm:grid-cols-2">
-                <StatCard
-                  label="Avg Price (Shells 🐚)"
-                  value={(data.avg_price_points ?? 0).toFixed(1)}
-                  icon={<Coins size={18} />}
-                  description="Average price for Shells-based tasks"
-                />
-                <StatCard
-                  label="Avg Price (USDC)"
-                  value={`$${(data.avg_price_usdc ?? 0).toFixed(2)}`}
-                  icon={<CircleDollarSign size={18} />}
-                  description="Average price for USDC-based tasks"
-                />
-              </div>
-            </div>
-          )}
-
-          {/* x402 USDC Payment Stats */}
+          {/* 3-Currency Breakdown */}
           <div>
-            <div className="flex items-center gap-3 mb-4">
-              <h2 className="text-lg font-semibold">x402 USDC Payments</h2>
-              <span className="flex items-center gap-1.5 text-xs font-medium bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300 px-2.5 py-1 rounded-full">
-                <ExternalLink size={11} />
-                {envNetworkLabel}
-              </span>
-            </div>
-
-            {/* Per-network breakdown (shown when data from multiple networks exists) */}
-            {hasMultipleNetworks && (
-              <div className="space-y-6 mb-6">
-                {networkEntries.map(([network, stats]) => (
-                  <div key={network}>
-                    <div className="flex items-center gap-2 mb-3">
-                      <span className="text-sm font-medium text-muted-foreground">
-                        {getNetworkLabel(network)}
-                      </span>
-                      <span className="text-xs bg-muted px-2 py-0.5 rounded font-mono">{network}</span>
-                    </div>
-                    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-                      <StatCard
-                        label="USDC Tasks"
-                        value={stats.usdc_tasks}
-                        icon={<CircleDollarSign size={18} />}
-                        description="Tasks paid via USDC"
-                      />
-                      <StatCard
-                        label="USDC Volume"
-                        value={`$${stats.total_usdc_volume.toFixed(2)}`}
-                        icon={<Coins size={18} />}
-                        description="Escrow + payout transactions"
-                      />
-                      <StatCard
-                        label="Unique Payers"
-                        value={stats.unique_payers}
-                        icon={<Wallet size={18} />}
-                        description="Distinct payer wallets"
-                      />
-                      <StatCard
-                        label="Unique Recipients"
-                        value={stats.unique_recipients}
-                        icon={<Users size={18} />}
-                        description="Distinct recipient wallets"
-                      />
-                    </div>
-                  </div>
-                ))}
-                <div>
-                  <span className="text-sm font-medium text-muted-foreground">All Networks (Total)</span>
+            <h2 className="text-lg font-semibold mb-4">Currencies</h2>
+            <div className="grid gap-4 sm:grid-cols-1 lg:grid-cols-3">
+              {/* Shells */}
+              <CurrencySection
+                title="Shells"
+                emoji="🐚"
+                badge={
+                  <span className="text-xs bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300 px-2 py-0.5 rounded-full font-medium">
+                    off-chain
+                  </span>
+                }
+              >
+                <div className="space-y-3">
+                  <StatCard
+                    label="Total Supply"
+                    value={(data.currencies?.shells.total_supply ?? data.total_points_supply).toFixed(0)}
+                    icon={<Coins size={16} />}
+                    description="Circulating Shells balance"
+                  />
+                  <StatCard
+                    label="Total Spent"
+                    value={(data.currencies?.shells.total_spent ?? data.shells_spent ?? 0).toFixed(0)}
+                    icon={<TrendingDown size={16} />}
+                    description="Shells paid for tasks"
+                  />
+                  <StatCard
+                    label="Avg Task Price"
+                    value={(data.currencies?.shells.avg_task_price ?? data.avg_price_points ?? 0).toFixed(1)}
+                    icon={<CircleDollarSign size={16} />}
+                    description="Average Shells per task"
+                  />
                 </div>
-              </div>
-            )}
+              </CurrencySection>
 
-            {/* Total stats (always shown) */}
-            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-              <StatCard
-                label="USDC Tasks"
-                value={data.x402?.total?.usdc_tasks ?? 0}
-                icon={<CircleDollarSign size={18} />}
-                description="Tasks paid via USDC"
-              />
-              <StatCard
-                label="Total USDC Volume"
-                value={`$${(data.x402?.total?.total_usdc_volume ?? 0).toFixed(2)}`}
-                icon={<Coins size={18} />}
-                description="Escrow + payout transactions"
-              />
-              <StatCard
-                label="Unique Payers"
-                value={data.x402?.total?.unique_payers ?? 0}
-                icon={<Wallet size={18} />}
-                description="Distinct payer wallets"
-              />
-              <StatCard
-                label="Unique Recipients"
-                value={data.x402?.total?.unique_recipients ?? 0}
-                icon={<Users size={18} />}
-                description="Distinct recipient wallets"
-              />
+              {/* USDC Sepolia */}
+              <CurrencySection
+                title="USDC Sepolia"
+                badge={
+                  <span className="text-xs bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300 px-2 py-0.5 rounded-full font-medium">
+                    testnet
+                  </span>
+                }
+              >
+                <div className="space-y-3">
+                  <StatCard
+                    label="Total Volume"
+                    value={`$${(data.currencies?.usdc_sepolia.total_volume ?? 0).toFixed(2)}`}
+                    icon={<Coins size={16} />}
+                    description="USDC transacted on Sepolia"
+                  />
+                  <StatCard
+                    label="Task Count"
+                    value={data.currencies?.usdc_sepolia.task_count ?? 0}
+                    icon={<ListTodo size={16} />}
+                    description="Tasks paid on Sepolia"
+                  />
+                  <StatCard
+                    label="Unique Payers"
+                    value={data.currencies?.usdc_sepolia.unique_payers ?? 0}
+                    icon={<Wallet size={16} />}
+                    description="Distinct payer wallets"
+                  />
+                </div>
+              </CurrencySection>
+
+              {/* USDC Mainnet */}
+              <CurrencySection
+                title="USDC Mainnet"
+                badge={
+                  <span className="text-xs bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-300 px-2 py-0.5 rounded-full font-medium">
+                    mainnet
+                  </span>
+                }
+              >
+                <div className="space-y-3">
+                  <StatCard
+                    label="Total Volume"
+                    value={`$${(data.currencies?.usdc_mainnet.total_volume ?? 0).toFixed(2)}`}
+                    icon={<Coins size={16} />}
+                    description="USDC transacted on Base"
+                  />
+                  <StatCard
+                    label="Task Count"
+                    value={data.currencies?.usdc_mainnet.task_count ?? 0}
+                    icon={<ListTodo size={16} />}
+                    description="Tasks paid on Base Mainnet"
+                  />
+                  <StatCard
+                    label="Unique Payers"
+                    value={data.currencies?.usdc_mainnet.unique_payers ?? 0}
+                    icon={<Wallet size={16} />}
+                    description="Distinct payer wallets"
+                  />
+                </div>
+              </CurrencySection>
             </div>
           </div>
         </div>

--- a/frontend/src/pages/dashboard/MyTasks.tsx
+++ b/frontend/src/pages/dashboard/MyTasks.tsx
@@ -5,7 +5,48 @@ import { getDashboardToken } from '@/components/dashboard/DashboardAccess';
 import StatusBadge from '@/components/shared/StatusBadge';
 import Pagination from '@/components/shared/Pagination';
 import { Skeleton } from '@/components/ui/skeleton';
-import { ExternalLink, DollarSign } from 'lucide-react';
+import { ExternalLink } from 'lucide-react';
+
+const NETWORK_SEPOLIA = 'eip155:84532';
+const NETWORK_MAINNET = 'eip155:8453';
+
+function getExplorerUrl(txHash: string, network: string | null | undefined): string {
+  const base = network === NETWORK_MAINNET
+    ? 'https://basescan.org/tx/'
+    : 'https://sepolia.basescan.org/tx/';
+  return `${base}${txHash}`;
+}
+
+function TaskPrice({ task }: { task: { payment_mode?: string | null; price_points?: number | null; price_usdc?: number | null; network?: string | null; escrow_tx_hash?: string | null } }) {
+  const { payment_mode, price_points, price_usdc, network, escrow_tx_hash } = task;
+  if (payment_mode === 'usdc' && price_usdc != null) {
+    const isMainnet = network === NETWORK_MAINNET;
+    const isSepolia = network === NETWORK_SEPOLIA;
+    const explorerUrl = escrow_tx_hash ? getExplorerUrl(escrow_tx_hash, network) : null;
+    const label = isMainnet ? `$${price_usdc} USDC` : `$${price_usdc} USDC${isSepolia ? ' (testnet)' : ''}`;
+    return (
+      <span className="flex items-center gap-1">
+        <span className="text-blue-600 dark:text-blue-400 font-medium">{label}</span>
+        {explorerUrl && (
+          <a
+            href={explorerUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={(e) => e.stopPropagation()}
+            className="text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-200"
+            title={isMainnet ? 'View on BaseScan' : 'View on BaseScan Sepolia'}
+          >
+            <ExternalLink size={12} />
+          </a>
+        )}
+      </span>
+    );
+  }
+  if (price_points != null) {
+    return <span className="flex items-center gap-1">{price_points} 🐚</span>;
+  }
+  return <span className="text-muted-foreground">—</span>;
+}
 
 const LIMIT = 20;
 type Role = 'all' | 'creator' | 'executor';
@@ -77,9 +118,7 @@ export default function MyTasks() {
                       <td className="p-3 text-muted-foreground capitalize hidden sm:table-cell">{t.category}</td>
                       <td className="p-3"><StatusBadge status={t.status} /></td>
                       <td className="p-3 text-muted-foreground hidden md:table-cell">
-                        {t.price_points != null && (
-                          <span className="flex items-center gap-1">{t.price_points} 🐚</span>
-                        )}
+                        <TaskPrice task={t} />
                       </td>
                       <td className="p-3 text-muted-foreground hidden lg:table-cell">
                         {t.created_at ? new Date(t.created_at).toLocaleDateString() : '—'}

--- a/frontend/src/pages/explore/TaskDetail.tsx
+++ b/frontend/src/pages/explore/TaskDetail.tsx
@@ -1,8 +1,58 @@
 import { useParams, Link } from 'react-router-dom';
-import { ArrowLeft, Clock, DollarSign } from 'lucide-react';
+import { ArrowLeft, Clock, ExternalLink } from 'lucide-react';
 import { useTask, useTaskSubmissions, useTaskValidations } from '@/api/queries';
 import StatusBadge from '@/components/shared/StatusBadge';
 import { Skeleton } from '@/components/ui/skeleton';
+import type { Task } from '@/api/queries';
+
+const NETWORK_SEPOLIA = 'eip155:84532';
+const NETWORK_MAINNET = 'eip155:8453';
+
+function TaskPriceBadge({ task }: { task: Task }) {
+  const { payment_mode, price_points, price_usdc, network, escrow_tx_hash } = task;
+
+  if (payment_mode === 'usdc' && price_usdc != null) {
+    const isMainnet = network === NETWORK_MAINNET;
+    const isSepolia = network === NETWORK_SEPOLIA;
+    const explorerBase = isMainnet ? 'https://basescan.org/tx/' : 'https://sepolia.basescan.org/tx/';
+    const explorerUrl = escrow_tx_hash ? `${explorerBase}${escrow_tx_hash}` : null;
+    const networkLabel = isMainnet ? 'Base Mainnet' : isSepolia ? 'Base Sepolia (testnet)' : network ?? 'USDC';
+
+    return (
+      <div className="flex flex-col gap-1">
+        <span className="text-2xl font-bold text-blue-600 dark:text-blue-400">
+          ${price_usdc} USDC
+        </span>
+        <div className="flex items-center gap-2">
+          <span className="text-xs bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300 px-2 py-0.5 rounded">
+            {networkLabel}
+          </span>
+          {explorerUrl && (
+            <a
+              href={explorerUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-1 text-xs text-blue-600 dark:text-blue-400 hover:underline"
+            >
+              <ExternalLink size={11} />
+              View escrow tx
+            </a>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  if (price_points != null) {
+    return (
+      <span className="text-2xl font-bold">
+        {price_points} 🐚
+      </span>
+    );
+  }
+
+  return null;
+}
 
 export default function TaskDetail() {
   const { taskId } = useParams<{ taskId: string }>();
@@ -41,13 +91,14 @@ export default function TaskDetail() {
           <StatusBadge status={task.status} />
         </div>
 
+        {/* Price — shown prominently */}
+        <div className="mb-4 p-4 rounded-lg bg-muted/50 border">
+          <p className="text-xs text-muted-foreground mb-1 uppercase tracking-wide font-medium">Reward</p>
+          <TaskPriceBadge task={task} />
+        </div>
+
         <div className="flex flex-wrap gap-3 text-sm text-muted-foreground mb-4">
           <span className="bg-muted px-2 py-1 rounded capitalize">{task.category}</span>
-          {task.price_points != null && (
-            <span className="flex items-center gap-1">
-              {task.price_points} 🐚
-            </span>
-          )}
           {task.created_at && (
             <span className="flex items-center gap-1">
               <Clock size={13} />{new Date(task.created_at).toLocaleDateString()}

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { eq, desc, and, or } from 'drizzle-orm';
+import { eq, desc, and, or, inArray } from 'drizzle-orm';
 import { db } from '../db/pool.js';
 import {
   agents,
@@ -7,6 +7,7 @@ import {
   bids,
   transactions,
   webhookDeliveries,
+  x402Payments,
 } from '../db/schema/index.js';
 import { viewTokenMiddleware } from '../auth.js';
 
@@ -31,6 +32,7 @@ dashboardRouter.get('/:agentId', viewTokenMiddleware as any, async (c) => {
       category: tasks.category,
       status: tasks.status,
       price_points: tasks.pricePoints,
+      price_usdc: tasks.priceUsdc,
       payment_mode: tasks.paymentMode,
       escrow_tx_hash: tasks.escrowTxHash,
       creator_agent_id: tasks.creatorAgentId,
@@ -41,6 +43,17 @@ dashboardRouter.get('/:agentId', viewTokenMiddleware as any, async (c) => {
     .where(or(eq(tasks.creatorAgentId, agentId), eq(tasks.executorAgentId, agentId))!)
     .orderBy(desc(tasks.createdAt))
     .limit(5);
+
+  // Fetch network for USDC tasks from x402_payments
+  const recentTaskIds = recentTasks.filter((t) => t.payment_mode === 'usdc').map((t) => t.id);
+  const recentPayments = recentTaskIds.length
+    ? await db
+        .select({ taskId: x402Payments.taskId, network: x402Payments.network })
+        .from(x402Payments)
+        .where(and(eq(x402Payments.paymentType, 'escrow'), inArray(x402Payments.taskId, recentTaskIds)))
+    : [];
+  const recentNetworkByTask = new Map(recentPayments.map((p) => [p.taskId, p.network]));
+  const envNetwork = process.env.BASE_NETWORK ?? null;
 
   const recentTxs = await db
     .select()
@@ -70,8 +83,12 @@ dashboardRouter.get('/:agentId', viewTokenMiddleware as any, async (c) => {
       category: t.category,
       status: t.status,
       price_points: t.price_points ? parseFloat(t.price_points) : null,
+      price_usdc: t.price_usdc ? parseFloat(t.price_usdc) : null,
       payment_mode: t.payment_mode ?? 'points',
       escrow_tx_hash: t.escrow_tx_hash ?? null,
+      network: t.payment_mode === 'usdc'
+        ? (recentNetworkByTask.get(t.id) ?? envNetwork)
+        : null,
       creator_agent_id: t.creator_agent_id,
       executor_agent_id: t.executor_agent_id,
       created_at: (t.created_at as Date | null)?.toISOString() ?? null,
@@ -125,6 +142,17 @@ dashboardRouter.get('/:agentId/tasks', viewTokenMiddleware as any, async (c) => 
     .limit(limit)
     .offset(offset);
 
+  // Fetch network for USDC tasks
+  const usdcTaskIds = rows.filter((t) => t.paymentMode === 'usdc').map((t) => t.id);
+  const taskPayments = usdcTaskIds.length
+    ? await db
+        .select({ taskId: x402Payments.taskId, network: x402Payments.network })
+        .from(x402Payments)
+        .where(and(eq(x402Payments.paymentType, 'escrow'), inArray(x402Payments.taskId, usdcTaskIds)))
+    : [];
+  const taskNetworkMap = new Map(taskPayments.map((p) => [p.taskId, p.network]));
+  const baseNetwork = process.env.BASE_NETWORK ?? null;
+
   return c.json({
     tasks: rows.map((t) => ({
       id: t.id,
@@ -134,8 +162,12 @@ dashboardRouter.get('/:agentId/tasks', viewTokenMiddleware as any, async (c) => 
       title: t.title,
       description: t.description,
       price_points: t.pricePoints ? parseFloat(t.pricePoints) : null,
+      price_usdc: t.priceUsdc ? parseFloat(t.priceUsdc) : null,
       payment_mode: t.paymentMode ?? 'points',
       escrow_tx_hash: t.escrowTxHash ?? null,
+      network: t.paymentMode === 'usdc'
+        ? (taskNetworkMap.get(t.id) ?? baseNetwork)
+        : null,
       status: t.status,
       deadline: t.deadline?.toISOString() ?? null,
       created_at: t.createdAt?.toISOString(),

--- a/src/routes/public.ts
+++ b/src/routes/public.ts
@@ -40,19 +40,33 @@ publicRouter.get('/feed', async (c) => {
         .where(and(eq(submissions.status, 'approved'), inArray(submissions.taskId, taskIds)))
     : [];
 
+  // Fetch escrow network per task from x402_payments
+  const payments = taskIds.length
+    ? await db
+        .select({ taskId: x402Payments.taskId, network: x402Payments.network })
+        .from(x402Payments)
+        .where(and(eq(x402Payments.paymentType, 'escrow'), inArray(x402Payments.taskId, taskIds)))
+    : [];
+
   const subByTask = new Map(subs.map((s) => [s.taskId, s]));
+  const networkByTask = new Map(payments.map((p) => [p.taskId, p.network]));
+  const envNetwork = process.env.BASE_NETWORK ?? null;
 
   return c.json({
     tasks: completed.map((t) => {
       const s = subByTask.get(t.id);
+      const network = t.paymentMode === 'usdc'
+        ? (networkByTask.get(t.id) ?? envNetwork)
+        : null;
       return {
         id: t.id,
         category: t.category,
         title: t.title,
-        price_points: t.pricePoints,
+        price_points: t.pricePoints ? parseFloat(t.pricePoints) : null,
         price_usdc: t.priceUsdc ? parseFloat(t.priceUsdc) : null,
         payment_mode: t.paymentMode,
         escrow_tx_hash: t.escrowTxHash ?? null,
+        network,
         status: t.status,
         completed_at: t.updatedAt?.toISOString(),
         result_url: s?.resultUrl ?? null,
@@ -212,6 +226,9 @@ publicRouter.get('/stats', async (c) => {
     };
   }
 
+  const sepoliaStats = networks['eip155:84532'];
+  const mainnetStats = networks['eip155:8453'];
+
   return c.json({
     agents: Number((agentsCount as { n: number })?.n ?? 0),
     verified_agents: Number((verifiedCount as { n: number })?.n ?? 0),
@@ -222,6 +239,24 @@ publicRouter.get('/stats', async (c) => {
     tasks_by_status: tasksByStatus,
     avg_price_points: parseFloat(String((avgPricesRaw as { avg_points: string; avg_usdc: string })?.avg_points ?? '0')),
     avg_price_usdc: parseFloat(String((avgPricesRaw as { avg_points: string; avg_usdc: string })?.avg_usdc ?? '0')),
+    // 3-currency breakdown (canonical structure for frontend)
+    currencies: {
+      shells: {
+        total_supply: parseFloat(String((supply as { total: string })?.total ?? '0')),
+        total_spent: parseFloat(String((shellsSpent as { total: string })?.total ?? '0')),
+        avg_task_price: parseFloat(String((avgPricesRaw as { avg_points: string; avg_usdc: string })?.avg_points ?? '0')),
+      },
+      usdc_sepolia: {
+        total_volume: sepoliaStats?.total_usdc_volume ?? 0,
+        task_count: sepoliaStats?.usdc_tasks ?? 0,
+        unique_payers: sepoliaStats?.unique_payers ?? 0,
+      },
+      usdc_mainnet: {
+        total_volume: mainnetStats?.total_usdc_volume ?? 0,
+        task_count: mainnetStats?.usdc_tasks ?? 0,
+        unique_payers: mainnetStats?.unique_payers ?? 0,
+      },
+    },
     x402: {
       networks,
       total: {


### PR DESCRIPTION
## Summary

Addresses issue #61 — adds proper 3-currency support throughout the app.

## Backend changes

### `GET /v1/public/feed`
- Added `network` field per task (joined from `x402_payments` escrow row, falls back to `BASE_NETWORK` env for tasks without payment record)
- Fixed `price_points` to parse as float (was returning raw decimal string)

### `GET /v1/public/stats`
- Added `currencies` block with clean 3-currency breakdown:
  - `shells`: total_supply, total_spent, avg_task_price
  - `usdc_sepolia`: total_volume, task_count, unique_payers
  - `usdc_mainnet`: total_volume, task_count, unique_payers
- Existing `x402` block preserved for backward compat

### `GET /v1/dashboard/:id` and `GET /v1/dashboard/:id/tasks`
- Added `price_usdc` and `network` fields to both recent_tasks and full task list
- Network resolved from x402_payments escrow join (falls back to BASE_NETWORK env)

## Frontend changes

### `Task` type (`queries.ts`)
- Added `price_usdc?: number | null`
- Added `network?: string | null` (EIP-155 format: `eip155:8453` / `eip155:84532`)
- Typed `usePublicFeed` return as `Task[]`
- Added `CurrenciesStats` interface + `currencies` field to `PlatformStats`

### `TaskCard` component
- New `PriceBadge` subcomponent handles all 3 currencies:
  - Shells: `{price_points} 🐚`
  - USDC Sepolia: `${price_usdc} USDC (testnet)` with BaseScan Sepolia link
  - USDC Mainnet: `${price_usdc} USDC` with BaseScan link

### `TaskDetail` page
- Price now shown prominently in a dedicated reward box above description
- Shows network label (Base Mainnet / Base Sepolia) and escrow tx link

### `MyTasks` dashboard page
- `TaskPrice` component in the Price column handles all 3 currencies with testnet/mainnet distinction and tx links

### `Stats.tsx`
- Replaced x402 block with a **3-currency breakdown section**:
  - 🐚 Shells (off-chain): supply, spent, avg price
  - USDC Sepolia (testnet): volume, task count, unique payers
  - USDC Mainnet (mainnet): volume, task count, unique payers