### PR TITLE
fix: cast Buffer to Uint8Array for BlobPart compatibility

### DIFF
--- a/src/tests/files.test.ts
+++ b/src/tests/files.test.ts
@@ -223,7 +223,7 @@ function makeUploadRequest(params: {
   authKey?: string;
 }): Request {
   const formData = new FormData();
-  const blob = new Blob([params.buffer], { type: params.mimetype });
+  const blob = new Blob([new Uint8Array(params.buffer)], { type: params.mimetype });
   formData.append('file', blob, params.filename);
   formData.append('entity_type', params.entityType);
   formData.append('entity_id', params.entityId);


### PR DESCRIPTION
## Summary

Addresses issue #75

In `src/tests/files.test.ts` line 226, `Buffer` was being passed directly to `new Blob()` where a `BlobPart` is expected. TypeScript 5.x tightened its `BlobPart` type definition and no longer accepts `Buffer<ArrayBufferLike>` directly.

**Fix:** Convert the buffer to `Uint8Array` (which is a valid `BlobPart`) before passing it to `Blob`.

```ts
// Before
const blob = new Blob([params.buffer], { type: params.mimetype });

// After
const blob = new Blob([new Uint8Array(params.buffer)], { type: params.mimetype });
```

- ✅ `tsc` exits with code 0
- 🚀 Unblocks Docker build and deployment of recurring tasks feature