### PR TITLE
feat: Daily Shells emission with activity multiplier and decay (#81)

### DIFF
--- a/drizzle/migrations/0009_daily_emission.sql
+++ b/drizzle/migrations/0009_daily_emission.sql
@@ -1,0 +1,2 @@
+-- Migration: Add api_calls_7d to agents for daily emission tracking (Variant A)
+ALTER TABLE agents ADD COLUMN IF NOT EXISTS api_calls_7d INTEGER NOT NULL DEFAULT 0;

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -58,8 +58,13 @@ export async function authMiddleware(c: Context<{ Variables: AppVariables }>, ne
   c.set('agent', agent);
   c.set('agentId', agent.id);
 
-  // Update last_api_call_at for emission eligibility (fire-and-forget)
-  db.execute(sql`UPDATE agents SET last_api_call_at = NOW() WHERE id = ${agentId}`).catch(() => {});
+  // Update last_api_call_at and increment 7-day call counter for emission eligibility (fire-and-forget)
+  db.execute(sql`
+    UPDATE agents
+    SET last_api_call_at = NOW(),
+        api_calls_7d = api_calls_7d + 1
+    WHERE id = ${agentId}
+  `).catch(() => {});
 
   await next();
 }

--- a/src/db/schema/agents.ts
+++ b/src/db/schema/agents.ts
@@ -20,6 +20,7 @@ export const agents = pgTable('agents', {
   evmAddress: varchar('evm_address', { length: 42 }),                     // EVM wallet address for USDC payouts
   apiKeyHash: varchar('api_key_hash', { length: 128 }).notNull(),         // bcrypt hash of API key
   lastApiCallAt: timestamp('last_api_call_at', { withTimezone: true }),   // For emission eligibility
+  apiCalls7d: integer('api_calls_7d').default(0),                        // Rolling 7-day API call counter (reset at emission run)
   verifiedAt: timestamp('verified_at', { withTimezone: true }),
   verificationTweetUrl: text('verification_tweet_url'),
   createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,8 @@ import { filesRouter } from './routes/files.js';
 import { adminRouter } from './routes/admin.js';
 import { recurringTasksAdminRouter } from './routes/recurringTasks.js';
 import { initRecurringScheduler } from './services/recurringScheduler.js';
+import { runDailyEmission } from './services/emissionService.js';
+import cron from 'node-cron';
 
 const app = new Hono();
 
@@ -181,3 +183,10 @@ setInterval(() => runValidationDeadlineResolution().catch(() => {}), 60_000);
 initRecurringScheduler().catch((err) => {
   console.error('Failed to initialize recurring scheduler:', err);
 });
+
+// Daily emission cron — runs at 00:00 UTC every day
+cron.schedule('0 0 * * *', () => {
+  runDailyEmission().catch((err) => {
+    console.error('[EmissionService] Daily emission cron failed:', err);
+  });
+}, { timezone: 'UTC' });

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -14,6 +14,7 @@ import {
   transactions,
   x402Payments,
 } from '../db/schema/index.js';
+import { runDailyEmission } from '../services/emissionService.js';
 
 export const adminRouter = new Hono();
 
@@ -397,4 +398,33 @@ adminRouter.get('/stats', async (c) => {
       usdc: parseFloat(platformFees[0]?.usdc_fees ?? '0'),
     },
   });
+});
+
+// ---------------------------------------------------------------------------
+// POST /v1/admin/economy/run-emission
+// ---------------------------------------------------------------------------
+
+/**
+ * POST /v1/admin/economy/run-emission
+ * Manually trigger the daily emission run (for testing / backfill).
+ * Protected by ADMIN_SECRET.
+ */
+adminRouter.post('/economy/run-emission', async (c) => {
+  try {
+    const result = await runDailyEmission();
+    return c.json({
+      ok: true,
+      run_at: result.runAt.toISOString(),
+      verified_agent_count: result.verifiedAgentCount,
+      base_emission: result.baseEmission,
+      eligible_agents: result.eligibleAgents,
+      total_shells_emitted: result.totalShellsEmitted,
+      skipped_cap: result.skippedCap,
+      skipped_inactive: result.skippedInactive,
+    });
+  } catch (err) {
+    const e = err as Error;
+    console.error('[Admin] run-emission failed:', e);
+    return c.json({ error: 'emission_failed', message: e.message }, 500);
+  }
 });

--- a/src/routes/public.ts
+++ b/src/routes/public.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono';
 import { eq, ne, desc, sql, and, inArray } from 'drizzle-orm';
 import { db } from '../db/pool.js';
 import { agents, tasks, submissions, x402Payments, transactions } from '../db/schema/index.js';
+import { getLastEmissionResult } from '../services/emissionService.js';
 
 export const publicRouter = new Hono();
 
@@ -266,6 +267,15 @@ publicRouter.get('/stats', async (c) => {
         unique_recipients: Number((uniqueRecipients as { n: number })?.n ?? 0),
       },
     },
+    emission: (() => {
+      const last = getLastEmissionResult();
+      if (!last) return { last_emission_run_at: null, last_emission_total_shells: null, last_emission_agent_count: null };
+      return {
+        last_emission_run_at: last.runAt.toISOString(),
+        last_emission_total_shells: last.totalShellsEmitted,
+        last_emission_agent_count: last.eligibleAgents,
+      };
+    })(),
   });
 });
 

--- a/src/services/emissionService.ts
+++ b/src/services/emissionService.ts
@@ -1,0 +1,244 @@
+/**
+ * Daily Emission Service
+ *
+ * Implements the Shells emission economy as defined in shells-economy.md.
+ *
+ * Formula:
+ *   IF agent.status == 'verified'
+ *   AND last_api_call_at < 7 days ago? NO → eligible
+ *   AND agent.balance_points < 5000 (MAX_BALANCE_CAP)
+ *   THEN:
+ *     emission = BASE_EMISSION × activity_multiplier
+ *
+ * Activity multiplier (based on api_calls_7d):
+ *   0 calls       → 0x (no emission)
+ *   1–5 calls     → 0.5x
+ *   6–20 calls    → 1.0x
+ *   21–50 + 1 gig → 1.25x
+ *   51+ + 2+ gigs → 1.5x
+ *
+ * Emission decay (based on verified agent count):
+ *   1–100         → 20 🐚/day base
+ *   101–250       → 15 🐚/day base
+ *   251–500       → 10 🐚/day base
+ *   501–1000      → 7 🐚/day base
+ *   1001+         → 5 🐚/day base
+ *
+ * Balance cap: 5000 — no emission if already at cap (cap only for emission, not gig earnings).
+ */
+
+import { eq, lt, gte, and, sql } from 'drizzle-orm';
+import { dbDirect } from '../db/pool.js';
+import { agents, transactions } from '../db/schema/index.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const MAX_BALANCE_CAP = 5000;
+const MAX_INACTIVITY_DAYS = 7;
+
+// Emission decay tiers by verified agent count
+const EMISSION_DECAY_TIERS: { maxAgents: number; base: number }[] = [
+  { maxAgents: 100, base: 20 },
+  { maxAgents: 250, base: 15 },
+  { maxAgents: 500, base: 10 },
+  { maxAgents: 1000, base: 7 },
+  { maxAgents: Infinity, base: 5 },
+];
+
+// ---------------------------------------------------------------------------
+// Emission state (persisted in memory; populated after each run)
+// ---------------------------------------------------------------------------
+
+export interface EmissionRunResult {
+  runAt: Date;
+  verifiedAgentCount: number;
+  baseEmission: number;
+  eligibleAgents: number;
+  totalShellsEmitted: number;
+  skippedCap: number;
+  skippedInactive: number;
+}
+
+let lastEmissionResult: EmissionRunResult | null = null;
+
+/**
+ * Returns the result of the last emission run, or null if never run.
+ */
+export function getLastEmissionResult(): EmissionRunResult | null {
+  return lastEmissionResult;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Determine base emission from the decay table.
+ */
+export function getBaseEmission(verifiedCount: number): number {
+  for (const tier of EMISSION_DECAY_TIERS) {
+    if (verifiedCount <= tier.maxAgents) return tier.base;
+  }
+  return 5;
+}
+
+/**
+ * Determine activity multiplier.
+ *
+ * @param apiCalls7d   Number of API calls in the last 7 days
+ * @param gigsLast7d   Number of completed gigs (task_payment transactions) in the last 7 days
+ */
+export function getActivityMultiplier(apiCalls7d: number, gigsLast7d: number): number {
+  if (apiCalls7d === 0) return 0;
+  if (apiCalls7d <= 5) return 0.5;
+  if (apiCalls7d <= 20) return 1.0;
+  if (apiCalls7d <= 50 && gigsLast7d >= 1) return 1.25;
+  if (apiCalls7d <= 50) return 1.0; // 21-50 without gig → 1.0x
+  if (gigsLast7d >= 2) return 1.5;
+  return 1.0; // 51+ without enough gigs → 1.0x
+}
+
+// ---------------------------------------------------------------------------
+// Core runner
+// ---------------------------------------------------------------------------
+
+/**
+ * Run the daily emission for all eligible verified agents.
+ * Called by the daily cron job at 00:00 UTC.
+ */
+export async function runDailyEmission(): Promise<EmissionRunResult> {
+  const runAt = new Date();
+  console.log(`[EmissionService] Starting daily emission run at ${runAt.toISOString()}`);
+
+  // 1. Count verified agents → determine base emission
+  const [verifiedCountRow] = await dbDirect
+    .select({ n: sql<number>`count(*)::int` })
+    .from(agents)
+    .where(eq(agents.status, 'verified'));
+
+  const verifiedAgentCount = Number(verifiedCountRow?.n ?? 0);
+  const baseEmission = getBaseEmission(verifiedAgentCount);
+
+  console.log(`[EmissionService] Verified agents: ${verifiedAgentCount}, base emission: ${baseEmission} 🐚`);
+
+  // 2. Fetch all verified agents that are under the balance cap and were active within 7 days
+  const cutoff = new Date(runAt.getTime() - MAX_INACTIVITY_DAYS * 24 * 60 * 60 * 1000);
+
+  const eligibleAgents = await dbDirect
+    .select({
+      id: agents.id,
+      balancePoints: agents.balancePoints,
+      apiCalls7d: agents.apiCalls7d,
+    })
+    .from(agents)
+    .where(
+      and(
+        eq(agents.status, 'verified'),
+        gte(agents.lastApiCallAt, cutoff),
+        lt(agents.balancePoints, String(MAX_BALANCE_CAP)),
+      ),
+    );
+
+  console.log(`[EmissionService] Eligible agents (active + under cap): ${eligibleAgents.length}`);
+
+  // 3. Calculate gigs completed in the last 7 days for each eligible agent
+  const sevenDaysAgo = new Date(runAt.getTime() - 7 * 24 * 60 * 60 * 1000);
+
+  let totalShellsEmitted = 0;
+  let skippedCap = 0;
+  let skippedInactive = 0;
+
+  for (const agent of eligibleAgents) {
+    const currentBalance = parseFloat(agent.balancePoints ?? '0');
+
+    // Double-check cap (might have been hit mid-run by other processes)
+    if (currentBalance >= MAX_BALANCE_CAP) {
+      skippedCap++;
+      continue;
+    }
+
+    // Count completed gigs in the last 7 days (task_payment transactions to this agent)
+    const [gigsRow] = await dbDirect
+      .select({ n: sql<number>`count(*)::int` })
+      .from(transactions)
+      .where(
+        and(
+          eq(transactions.toAgentId, agent.id),
+          eq(transactions.type, 'task_payment'),
+          gte(transactions.createdAt, sevenDaysAgo),
+        ),
+      );
+
+    const gigsLast7d = Number(gigsRow?.n ?? 0);
+    const apiCalls7d = agent.apiCalls7d ?? 0;
+    const multiplier = getActivityMultiplier(apiCalls7d, gigsLast7d);
+
+    if (multiplier === 0) {
+      // 0 API calls → no emission (inactive)
+      skippedInactive++;
+      continue;
+    }
+
+    const rawAmount = baseEmission * multiplier;
+    // Cap the credit so balance doesn't exceed MAX_BALANCE_CAP
+    const maxCredit = MAX_BALANCE_CAP - currentBalance;
+    const amount = Math.min(rawAmount, maxCredit);
+
+    if (amount <= 0) {
+      skippedCap++;
+      continue;
+    }
+
+    // Insert transaction + update balance atomically
+    await dbDirect.transaction(async (tx) => {
+      await tx.insert(transactions).values({
+        fromAgentId: null,
+        toAgentId: agent.id,
+        amount: amount.toFixed(2),
+        currency: 'points',
+        type: 'daily_emission',
+        memo: `Daily Shells emission (${apiCalls7d} calls, ${gigsLast7d} gigs, ${multiplier}x multiplier)`,
+      });
+
+      await tx
+        .update(agents)
+        .set({
+          balancePoints: sql`LEAST(balance_points + ${amount}, ${MAX_BALANCE_CAP})`,
+          updatedAt: sql`NOW()`,
+        })
+        .where(eq(agents.id, agent.id));
+    });
+
+    totalShellsEmitted += amount;
+    console.log(
+      `[EmissionService] Credited ${amount} 🐚 to ${agent.id} (${apiCalls7d} calls, ${gigsLast7d} gigs, ${multiplier}x)`,
+    );
+  }
+
+  // 4. Reset api_calls_7d for all verified agents (rolling window reset)
+  await dbDirect
+    .update(agents)
+    .set({ apiCalls7d: 0, updatedAt: sql`NOW()` })
+    .where(eq(agents.status, 'verified'));
+
+  const result: EmissionRunResult = {
+    runAt,
+    verifiedAgentCount,
+    baseEmission,
+    eligibleAgents: eligibleAgents.length,
+    totalShellsEmitted,
+    skippedCap,
+    skippedInactive,
+  };
+
+  lastEmissionResult = result;
+
+  console.log(
+    `[EmissionService] Done. Emitted ${totalShellsEmitted} 🐚 to ${eligibleAgents.length - skippedCap - skippedInactive} agents. ` +
+    `Skipped: ${skippedCap} (cap), ${skippedInactive} (inactive/0 calls).`,
+  );
+
+  return result;
+}

--- a/src/tests/emission.test.ts
+++ b/src/tests/emission.test.ts
@@ -1,29 +1,130 @@
 /**
- * Emission test — validates the daily emission pg_cron job logic.
- * Manually runs the emission SQL for a test agent and verifies:
- *   - Only active verified agents receive emission
- *   - Balance cap at 5000 is enforced
- *   - Inactive agents (>7 days) are skipped
+ * Emission tests — validates the daily emission service logic.
+ *
+ * Tests cover:
+ *   - Activity multiplier table (api_calls_7d × gigs_last_7d → multiplier)
+ *   - Emission decay table (verified agent count → base emission)
+ *   - Balance cap enforcement (5000 max)
+ *   - Full runDailyEmission() integration (per-agent crediting)
  *
  * Run: npm run test:emission
- * Requires: DATABASE_URL in .env (direct connection for pg_cron simulation)
+ * Requires: DATABASE_URL in .env
  */
 
 import 'dotenv/config';
-import { eq, sql } from 'drizzle-orm';
+import { eq, sql, and } from 'drizzle-orm';
 import { dbDirect, initPool } from '../db/pool.js';
 import { agents, transactions } from '../db/schema/index.js';
+import {
+  getActivityMultiplier,
+  getBaseEmission,
+  runDailyEmission,
+} from '../services/emissionService.js';
 
-const TEST_ACTIVE = 'agt_emtest1';
-const TEST_INACTIVE = 'agt_emtest2';
-const TEST_CAPPED = 'agt_emtest3';
-const TEST_UNVERIFIED = 'agt_emtest4';
+// ---------------------------------------------------------------------------
+// Unit tests: multiplier table
+// ---------------------------------------------------------------------------
+
+function testMultiplierTable() {
+  console.log('\n📐 Testing activity multiplier table...');
+
+  const cases: { calls: number; gigs: number; expected: number; label: string }[] = [
+    { calls: 0, gigs: 0, expected: 0, label: '0 calls → 0x' },
+    { calls: 1, gigs: 0, expected: 0.5, label: '1 call, 0 gigs → 0.5x' },
+    { calls: 5, gigs: 0, expected: 0.5, label: '5 calls → 0.5x' },
+    { calls: 6, gigs: 0, expected: 1.0, label: '6 calls → 1.0x' },
+    { calls: 20, gigs: 0, expected: 1.0, label: '20 calls → 1.0x' },
+    { calls: 21, gigs: 0, expected: 1.0, label: '21 calls, 0 gigs → 1.0x (no gig bonus)' },
+    { calls: 21, gigs: 1, expected: 1.25, label: '21 calls + 1 gig → 1.25x' },
+    { calls: 50, gigs: 1, expected: 1.25, label: '50 calls + 1 gig → 1.25x' },
+    { calls: 51, gigs: 0, expected: 1.0, label: '51 calls, 0 gigs → 1.0x' },
+    { calls: 51, gigs: 1, expected: 1.0, label: '51 calls, 1 gig → 1.0x (need 2+)' },
+    { calls: 51, gigs: 2, expected: 1.5, label: '51 calls + 2 gigs → 1.5x' },
+    { calls: 100, gigs: 5, expected: 1.5, label: '100 calls + 5 gigs → 1.5x' },
+  ];
+
+  let passed = 0;
+  let failed = 0;
+
+  for (const { calls, gigs, expected, label } of cases) {
+    const result = getActivityMultiplier(calls, gigs);
+    if (Math.abs(result - expected) < 0.001) {
+      console.log(`  ✅ ${label}`);
+      passed++;
+    } else {
+      console.error(`  ❌ ${label}: expected ${expected}, got ${result}`);
+      failed++;
+    }
+  }
+
+  if (failed > 0) {
+    throw new Error(`Multiplier table: ${failed} test(s) failed`);
+  }
+  console.log(`  → All ${passed} multiplier cases passed`);
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests: emission decay table
+// ---------------------------------------------------------------------------
+
+function testDecayTable() {
+  console.log('\n📉 Testing emission decay table...');
+
+  const cases: { count: number; expected: number; label: string }[] = [
+    { count: 1, expected: 20, label: '1 verified agent → 20 🐚' },
+    { count: 100, expected: 20, label: '100 verified agents → 20 🐚' },
+    { count: 101, expected: 15, label: '101 verified agents → 15 🐚' },
+    { count: 250, expected: 15, label: '250 verified agents → 15 🐚' },
+    { count: 251, expected: 10, label: '251 verified agents → 10 🐚' },
+    { count: 500, expected: 10, label: '500 verified agents → 10 🐚' },
+    { count: 501, expected: 7, label: '501 verified agents → 7 🐚' },
+    { count: 1000, expected: 7, label: '1000 verified agents → 7 🐚' },
+    { count: 1001, expected: 5, label: '1001 verified agents → 5 🐚' },
+    { count: 9999, expected: 5, label: '9999 verified agents → 5 🐚' },
+  ];
+
+  let passed = 0;
+  let failed = 0;
+
+  for (const { count, expected, label } of cases) {
+    const result = getBaseEmission(count);
+    if (result === expected) {
+      console.log(`  ✅ ${label}`);
+      passed++;
+    } else {
+      console.error(`  ❌ ${label}: expected ${expected}, got ${result}`);
+      failed++;
+    }
+  }
+
+  if (failed > 0) {
+    throw new Error(`Decay table: ${failed} test(s) failed`);
+  }
+  console.log(`  → All ${passed} decay cases passed`);
+}
+
+// ---------------------------------------------------------------------------
+// Integration tests: runDailyEmission()
+// ---------------------------------------------------------------------------
+
+const TEST_ACTIVE_LOW = 'agt_emtest1';    // 3 calls → 0.5x multiplier
+const TEST_ACTIVE_MID = 'agt_emtest2';   // 10 calls → 1.0x multiplier
+const TEST_ACTIVE_HIGH = 'agt_emtest3';  // 30 calls + 1 gig → 1.25x multiplier
+const TEST_CAPPED = 'agt_emtest4';       // balance 4995 → should cap at 5000
+const TEST_INACTIVE = 'agt_emtest5';    // last_api_call_at 8 days ago → skipped
+const TEST_UNVERIFIED = 'agt_emtest6';  // status=unverified → skipped
+const TEST_ZERO_CALLS = 'agt_emtest7';  // api_calls_7d=0 → 0x multiplier
+
+const ALL_TEST_IDS = [
+  TEST_ACTIVE_LOW, TEST_ACTIVE_MID, TEST_ACTIVE_HIGH,
+  TEST_CAPPED, TEST_INACTIVE, TEST_UNVERIFIED, TEST_ZERO_CALLS,
+];
 
 async function setup() {
-  console.log('🔧 Setting up emission test agents...');
+  console.log('\n🔧 Setting up integration test agents...');
 
-  // Clean
-  for (const id of [TEST_ACTIVE, TEST_INACTIVE, TEST_CAPPED, TEST_UNVERIFIED]) {
+  // Clean up prior runs
+  for (const id of ALL_TEST_IDS) {
     await dbDirect.execute(sql`DELETE FROM transactions WHERE to_agent_id = ${id}`);
     await dbDirect.execute(sql`DELETE FROM agents WHERE id = ${id}`);
   }
@@ -31,143 +132,173 @@ async function setup() {
   const now = new Date();
   const eightDaysAgo = new Date(now.getTime() - 8 * 24 * 60 * 60 * 1000);
 
-  await dbDirect.insert(agents).values([
-    {
-      id: TEST_ACTIVE,
-      name: 'Active Verified Agent',
-      ownerTwitter: 'em_test_active',
-      status: 'verified',
-      balancePoints: '100',
-      lastApiCallAt: now,
-      apiKeyHash: 'hash1',
-    },
-    {
-      id: TEST_INACTIVE,
-      name: 'Inactive Agent (8 days)',
-      ownerTwitter: 'em_test_inactive',
-      status: 'verified',
-      balancePoints: '100',
-      lastApiCallAt: eightDaysAgo,
-      apiKeyHash: 'hash2',
-    },
-    {
-      id: TEST_CAPPED,
-      name: 'Near-Cap Agent',
-      ownerTwitter: 'em_test_capped',
-      status: 'verified',
-      balancePoints: '4995',  // 5 points below 5000 cap
-      lastApiCallAt: now,
-      apiKeyHash: 'hash3',
-    },
-    {
-      id: TEST_UNVERIFIED,
-      name: 'Unverified Agent',
-      ownerTwitter: 'em_test_unverified',
-      status: 'unverified',
-      balancePoints: '100',
-      lastApiCallAt: now,
-      apiKeyHash: 'hash4',
-    },
-  ]);
-  console.log('  ✅ Emission test agents created');
+  // Insert test agents
+  await dbDirect.execute(sql`
+    INSERT INTO agents (id, name, owner_twitter, status, balance_points, last_api_call_at, api_calls_7d, api_key_hash)
+    VALUES
+      (${TEST_ACTIVE_LOW},   'Low-activity agent',    'em_test_low',    'verified',   '100',  ${now.toISOString()},          3,   'hash1'),
+      (${TEST_ACTIVE_MID},   'Mid-activity agent',    'em_test_mid',    'verified',   '100',  ${now.toISOString()},          10,  'hash2'),
+      (${TEST_ACTIVE_HIGH},  'High-activity agent',   'em_test_high',   'verified',   '100',  ${now.toISOString()},          30,  'hash3'),
+      (${TEST_CAPPED},       'Near-cap agent',        'em_test_capped', 'verified',   '4995', ${now.toISOString()},          10,  'hash4'),
+      (${TEST_INACTIVE},     'Inactive agent',        'em_test_inact',  'verified',   '100',  ${eightDaysAgo.toISOString()}, 10,  'hash5'),
+      (${TEST_UNVERIFIED},   'Unverified agent',      'em_test_unverf', 'unverified', '100',  ${now.toISOString()},          10,  'hash6'),
+      (${TEST_ZERO_CALLS},   'Zero-calls agent',      'em_test_zero',   'verified',   '100',  ${now.toISOString()},          0,   'hash7')
+  `);
+
+  // Insert a task_payment for TEST_ACTIVE_HIGH (so they qualify for 1.25x)
+  const fiveDaysAgo = new Date(now.getTime() - 5 * 24 * 60 * 60 * 1000);
+  await dbDirect.execute(sql`
+    INSERT INTO transactions (from_agent_id, to_agent_id, amount, currency, type, created_at)
+    VALUES (NULL, ${TEST_ACTIVE_HIGH}, '50', 'points', 'task_payment', ${fiveDaysAgo.toISOString()})
+  `);
+
+  console.log('  ✅ Test agents created');
 }
 
 async function cleanup() {
-  for (const id of [TEST_ACTIVE, TEST_INACTIVE, TEST_CAPPED, TEST_UNVERIFIED]) {
+  for (const id of ALL_TEST_IDS) {
     await dbDirect.execute(sql`DELETE FROM transactions WHERE to_agent_id = ${id}`);
     await dbDirect.execute(sql`DELETE FROM agents WHERE id = ${id}`);
   }
   console.log('🧹 Test data cleaned up');
 }
 
-async function runEmissionSQL() {
-  console.log('\n🔄 Running emission SQL (simulating pg_cron job)...');
+async function runIntegrationTests() {
+  console.log('\n🔄 Running runDailyEmission() integration test...');
 
-  // Mirrors the pg_cron daily-emission job, filtered to test agents only.
-  // Uses Drizzle transaction() to replicate the BEGIN/COMMIT semantics —
-  // pg_cron executes the same SQL in a single transaction on the server.
-  await dbDirect.transaction(async (tx) => {
-    await tx.execute(sql`
-      INSERT INTO transactions (from_agent_id, to_agent_id, amount, currency, type)
-      SELECT NULL, id, 20, 'points', 'daily_emission'
-      FROM agents
-      WHERE id IN (${TEST_ACTIVE}, ${TEST_INACTIVE}, ${TEST_CAPPED}, ${TEST_UNVERIFIED})
-        AND status = 'verified'
-        AND last_api_call_at > NOW() - INTERVAL '7 days'
-        AND balance_points < 5000
-    `);
+  const result = await runDailyEmission();
+  console.log('  Emission result:', JSON.stringify(result, null, 2));
 
-    await tx.execute(sql`
-      UPDATE agents SET balance_points = LEAST(balance_points + 20, 5000)
-      WHERE id IN (${TEST_ACTIVE}, ${TEST_INACTIVE}, ${TEST_CAPPED}, ${TEST_UNVERIFIED})
-        AND status = 'verified'
-        AND last_api_call_at > NOW() - INTERVAL '7 days'
-        AND balance_points < 5000
-    `);
-  });
-}
-
-async function verifyResults() {
-  console.log('\n📊 Verifying emission results...');
-
-  const allAgents = await dbDirect
-    .select({ id: agents.id, balance: agents.balancePoints, status: agents.status })
+  // Fetch agent balances after emission
+  const rows = await dbDirect
+    .select({ id: agents.id, balance: agents.balancePoints, apiCalls7d: agents.apiCalls7d })
     .from(agents)
-    .where(sql`id IN (${TEST_ACTIVE}, ${TEST_INACTIVE}, ${TEST_CAPPED}, ${TEST_UNVERIFIED})`);
+    .where(
+      sql`id IN (${TEST_ACTIVE_LOW}, ${TEST_ACTIVE_MID}, ${TEST_ACTIVE_HIGH}, ${TEST_CAPPED}, ${TEST_INACTIVE}, ${TEST_UNVERIFIED}, ${TEST_ZERO_CALLS})`
+    );
 
-  for (const agent of allAgents) {
-    const balance = parseFloat(agent.balance ?? '0');
-    console.log(`  ${agent.id}: ${balance} points (status: ${agent.status})`);
+  const byId = new Map(rows.map((r: { id: string; balance: string | null; apiCalls7d: number | null }) => [r.id, r]));
+
+  function balance(id: string): number {
+    return parseFloat(String(byId.get(id)?.balance ?? '0'));
   }
 
-  const active = allAgents.find(a => a.id === TEST_ACTIVE);
-  const inactive = allAgents.find(a => a.id === TEST_INACTIVE);
-  const capped = allAgents.find(a => a.id === TEST_CAPPED);
-  const unverified = allAgents.find(a => a.id === TEST_UNVERIFIED);
+  // Base emission for current verified count (should be 5 verified test agents)
+  // Note: real DB likely has other agents too, so we just verify relative to expected range
+  const base = result.baseEmission;
+  console.log(`  Base emission used: ${base} 🐚`);
 
-  // Active verified should receive 20 points
-  const activeBalance = parseFloat(active?.balance ?? '0');
-  if (Math.abs(activeBalance - 120) > 0.01) {
-    throw new Error(`Active agent should have 120 (100+20), got ${activeBalance}`);
-  }
-  console.log('\n  ✅ Active verified agent received emission (+20)');
+  let failures = 0;
 
-  // Inactive should NOT receive emission
-  const inactiveBalance = parseFloat(inactive?.balance ?? '0');
-  if (Math.abs(inactiveBalance - 100) > 0.01) {
-    throw new Error(`Inactive agent balance should be unchanged at 100, got ${inactiveBalance}`);
+  // TEST_ACTIVE_LOW: 3 calls → 0.5x → base * 0.5
+  const expectedLow = 100 + base * 0.5;
+  const actualLow = balance(TEST_ACTIVE_LOW);
+  if (Math.abs(actualLow - expectedLow) > 0.01) {
+    console.error(`  ❌ LOW agent: expected ~${expectedLow}, got ${actualLow}`);
+    failures++;
+  } else {
+    console.log(`  ✅ Low-activity agent: ${actualLow} (3 calls → 0.5x, +${base * 0.5} 🐚)`);
   }
-  console.log('  ✅ Inactive agent skipped (>7 days without API call)');
 
-  // Capped agent: was 4995, +20 would be 5015, capped to 5000
-  const cappedBalance = parseFloat(capped?.balance ?? '0');
-  if (Math.abs(cappedBalance - 5000) > 0.01) {
-    throw new Error(`Capped agent should be at 5000 (LEAST(4995+20, 5000)), got ${cappedBalance}`);
+  // TEST_ACTIVE_MID: 10 calls → 1.0x → base * 1.0
+  const expectedMid = 100 + base * 1.0;
+  const actualMid = balance(TEST_ACTIVE_MID);
+  if (Math.abs(actualMid - expectedMid) > 0.01) {
+    console.error(`  ❌ MID agent: expected ~${expectedMid}, got ${actualMid}`);
+    failures++;
+  } else {
+    console.log(`  ✅ Mid-activity agent: ${actualMid} (10 calls → 1.0x, +${base} 🐚)`);
   }
-  console.log('  ✅ Near-cap agent capped at 5000 (not 5015)');
 
-  // Unverified should NOT receive emission
-  const unverifiedBalance = parseFloat(unverified?.balance ?? '0');
-  if (Math.abs(unverifiedBalance - 100) > 0.01) {
-    throw new Error(`Unverified agent balance should be unchanged at 100, got ${unverifiedBalance}`);
+  // TEST_ACTIVE_HIGH: 30 calls + 1 gig → 1.25x → base * 1.25
+  const expectedHigh = 100 + base * 1.25;
+  const actualHigh = balance(TEST_ACTIVE_HIGH);
+  if (Math.abs(actualHigh - expectedHigh) > 0.01) {
+    console.error(`  ❌ HIGH agent: expected ~${expectedHigh}, got ${actualHigh}`);
+    failures++;
+  } else {
+    console.log(`  ✅ High-activity agent: ${actualHigh} (30 calls + 1 gig → 1.25x, +${base * 1.25} 🐚)`);
   }
-  console.log('  ✅ Unverified agent skipped');
+
+  // TEST_CAPPED: started at 4995, +base*1.0 (10 calls) but cap at 5000
+  const actualCapped = balance(TEST_CAPPED);
+  if (Math.abs(actualCapped - 5000) > 0.01) {
+    console.error(`  ❌ CAPPED agent: expected 5000 (cap), got ${actualCapped}`);
+    failures++;
+  } else {
+    console.log(`  ✅ Near-cap agent capped at 5000 (not ${4995 + base} 🐚)`);
+  }
+
+  // TEST_INACTIVE: 8 days ago → NOT eligible (lastApiCallAt < 7d cutoff)
+  const actualInactive = balance(TEST_INACTIVE);
+  if (Math.abs(actualInactive - 100) > 0.01) {
+    console.error(`  ❌ INACTIVE agent: expected 100 (unchanged), got ${actualInactive}`);
+    failures++;
+  } else {
+    console.log(`  ✅ Inactive agent skipped (>7 days since last API call)`);
+  }
+
+  // TEST_UNVERIFIED: not verified → NOT eligible
+  const actualUnverified = balance(TEST_UNVERIFIED);
+  if (Math.abs(actualUnverified - 100) > 0.01) {
+    console.error(`  ❌ UNVERIFIED agent: expected 100 (unchanged), got ${actualUnverified}`);
+    failures++;
+  } else {
+    console.log(`  ✅ Unverified agent skipped`);
+  }
+
+  // TEST_ZERO_CALLS: api_calls_7d=0 → 0x multiplier → skipped
+  const actualZero = balance(TEST_ZERO_CALLS);
+  if (Math.abs(actualZero - 100) > 0.01) {
+    console.error(`  ❌ ZERO-CALLS agent: expected 100 (unchanged), got ${actualZero}`);
+    failures++;
+  } else {
+    console.log(`  ✅ Zero-calls agent skipped (0x multiplier)`);
+  }
+
+  // api_calls_7d should be reset to 0 for verified agents
+  const verifiedIds = [TEST_ACTIVE_LOW, TEST_ACTIVE_MID, TEST_ACTIVE_HIGH, TEST_CAPPED, TEST_ZERO_CALLS];
+  for (const id of verifiedIds) {
+    const apiCalls = byId.get(id)?.apiCalls7d ?? -1;
+    if (apiCalls !== 0) {
+      console.error(`  ❌ api_calls_7d should be reset to 0 for ${id}, got ${apiCalls}`);
+      failures++;
+    }
+  }
+  console.log(`  ✅ api_calls_7d reset to 0 for all verified agents`);
+
+  if (failures > 0) {
+    throw new Error(`Integration tests: ${failures} test(s) failed`);
+  }
 }
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
 
 async function main() {
   console.log('🚀 UpMoltWork Emission Tests\n');
   await initPool();
 
   try {
+    // Unit tests (no DB needed)
+    testMultiplierTable();
+    testDecayTable();
+
+    // Integration tests
     await setup();
-    await runEmissionSQL();
-    await verifyResults();
+    await runIntegrationTests();
+
     console.log('\n✅ All emission tests passed!');
   } catch (err) {
     console.error('\n❌ Test failed:', err);
     process.exitCode = 1;
   } finally {
-    if (!process.env.KEEP_TEST_DATA) { await cleanup(); } else { console.log("🔒 KEEP_TEST_DATA set — skipping cleanup"); }
+    if (!process.env.KEEP_TEST_DATA) {
+      await cleanup();
+    } else {
+      console.log('🔒 KEEP_TEST_DATA set — skipping cleanup');
+    }
     process.exit(process.exitCode ?? 0);
   }
 }


### PR DESCRIPTION
## Summary

Implements the daily Shells emission economy from shells-economy.md.

## Changes

### DB Schema
- Added `api_calls_7d INTEGER DEFAULT 0` to `agents` table (Variant A)
- Migration: `drizzle/migrations/0009_daily_emission.sql`

### Auth Middleware (`src/auth.ts`)
- Increment `api_calls_7d` on every authenticated API call (alongside `last_api_call_at` update)

### Emission Service (`src/services/emissionService.ts`)
- `runDailyEmission()` — main entry point
- Emission decay by verified agent count: 20 / 15 / 10 / 7 / 5 🐚 base
- Activity multiplier (api_calls_7d × gigs_last_7d): 0x / 0.5x / 1x / 1.25x / 1.5x
- Balance cap at 5000 enforced (no emission when already at cap)
- All credits recorded as `daily_emission` transactions
- `api_calls_7d` reset to 0 for all verified agents after each run
- `getLastEmissionResult()` for public stats

### Cron Job (`src/index.ts`)
- `0 0 * * *` UTC daily via `node-cron`

### Admin Endpoint (`src/routes/admin.ts`)
- `POST /v1/admin/economy/run-emission` — manual trigger (protected by ADMIN_SECRET)

### Public Stats (`src/routes/public.ts`)
- Added `emission` block to `/v1/public/stats`:
  - `last_emission_run_at`
  - `last_emission_total_shells`
  - `last_emission_agent_count`

### Tests (`src/tests/emission.test.ts`)
- Unit tests: multiplier table (12 cases), decay table (10 cases)
- Integration tests: 7 agent scenarios covering cap, inactive, unverified, zero-calls, 0.5x, 1.0x, 1.25x multipliers

## Acceptance Criteria
- [x] Cron запускается ежедневно в 00:00 UTC
- [x] Multiplier корректно считается на основе активности
- [x] Balance cap 5000 соблюдается
- [x] Emission decay таблица применяется по количеству verified агентов
- [x] Все начисления записываются как транзакции типа `daily_emission`
- [x] Admin endpoint для ручного запуска
- [x] `/v1/public/stats` показывает данные о последней эмиссии
- [x] Тесты: multiplier таблица, cap, decay

Addresses issue #81