### PR TITLE
feat: add reputation_snapshots table, daily cron, and analytics queries

### DIFF
--- a/migrations/2026_03_15_0002_reputation_snapshots.sql
+++ b/migrations/2026_03_15_0002_reputation_snapshots.sql
@@ -1,0 +1,12 @@
+-- Create reputation_snapshots table for tracking agent reputation over time
+-- Used by the analytics endpoint to compute change_30d and history
+
+CREATE TABLE IF NOT EXISTS reputation_snapshots (
+  id            BIGSERIAL PRIMARY KEY,
+  agent_id      VARCHAR(12) NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+  score         NUMERIC(5, 2) NOT NULL,
+  recorded_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_reputation_snapshots_agent_recorded
+  ON reputation_snapshots (agent_id, recorded_at);

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -22,3 +22,4 @@ export { orderMessages } from './order_messages.js';
 export { fileAttachments } from './file_attachments.js';
 export { taskRatings } from './task_ratings.js';
 export { recurringTaskTemplates, recurringTaskInstances } from './recurringTasks.js';
+export { reputationSnapshots } from './reputation_snapshots.js';

--- a/src/db/schema/reputation_snapshots.ts
+++ b/src/db/schema/reputation_snapshots.ts
@@ -1,0 +1,11 @@
+import { pgTable, bigserial, varchar, decimal, timestamp, index } from 'drizzle-orm/pg-core';
+import { agents } from './agents.js';
+
+export const reputationSnapshots = pgTable('reputation_snapshots', {
+  id: bigserial('id', { mode: 'number' }).primaryKey(),
+  agentId: varchar('agent_id', { length: 12 }).notNull().references(() => agents.id, { onDelete: 'cascade' }),
+  score: decimal('score', { precision: 5, scale: 2 }).notNull(),
+  recordedAt: timestamp('recorded_at', { withTimezone: true }).defaultNow().notNull(),
+}, (table) => [
+  index('idx_reputation_snapshots_agent_recorded').on(table.agentId, table.recordedAt),
+]);

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ import { adminRouter } from './routes/admin.js';
 import { recurringTasksAdminRouter } from './routes/recurringTasks.js';
 import { initRecurringScheduler } from './services/recurringScheduler.js';
 import { runDailyEmission } from './services/emissionService.js';
+import { runDailyReputationSnapshot } from './services/reputationSnapshotService.js';
 
 const app = new Hono();
 
@@ -205,3 +206,10 @@ cron.schedule('*/15 * * * *', async () => {
   }
 });
 console.log('[TimeoutService] Scheduled: every 15 minutes');
+
+// Daily reputation snapshot cron — runs at 01:00 UTC every day (after emission)
+cron.schedule('0 1 * * *', () => {
+  runDailyReputationSnapshot().catch((err) => {
+    console.error('[ReputationSnapshot] Daily snapshot cron failed:', err);
+  });
+}, { timezone: 'UTC' });

--- a/src/routes/analytics.ts
+++ b/src/routes/analytics.ts
@@ -107,6 +107,41 @@ analyticsRouter.get('/:agentId/analytics', viewTokenMiddleware as any, async (c)
   `);
   const ratingRow = ratingResult.rows[0] as Record<string, unknown> ?? {};
 
+  // --- Reputation history (last 90 days, weekly buckets) ---
+  const repHistoryResult = await db.execute(sql`
+    SELECT
+      DATE_TRUNC('week', recorded_at)::date AS week,
+      AVG(score::numeric)                   AS avg_score
+    FROM reputation_snapshots
+    WHERE agent_id = ${agentId}
+      AND recorded_at >= NOW() - INTERVAL '90 days'
+    GROUP BY 1
+    ORDER BY 1
+  `);
+
+  type RepHistoryRow = { week: string | Date; avg_score: unknown };
+  const reputationHistory = (repHistoryResult.rows as RepHistoryRow[]).map((r) => ({
+    date: r.week instanceof Date ? r.week.toISOString().slice(0, 10) : String(r.week).slice(0, 10),
+    score: Math.round(safeFloat(r.avg_score) * 100) / 100,
+  }));
+
+  // --- Reputation change over 30 days ---
+  // Find the most recent snapshot at or before 30 days ago
+  const rep30dResult = await db.execute(sql`
+    SELECT score::numeric AS score
+    FROM reputation_snapshots
+    WHERE agent_id = ${agentId}
+      AND recorded_at <= NOW() - INTERVAL '30 days'
+    ORDER BY recorded_at DESC
+    LIMIT 1
+  `);
+
+  const rep30dRow = rep30dResult.rows[0] as Record<string, unknown> | undefined;
+  const reputationChange30d: number | null =
+    rep30dRow != null
+      ? Math.round((safeFloat(agent.reputationScore) - safeFloat(rep30dRow.score)) * 100) / 100
+      : null;
+
   return c.json({
     agent_id: agentId,
     period: 'all_time',
@@ -147,8 +182,8 @@ analyticsRouter.get('/:agentId/analytics', viewTokenMiddleware as any, async (c)
     },
     reputation: {
       current: safeFloat(agent.reputationScore),
-      change_30d: null, // requires reputation_snapshots table (not yet implemented)
-      history: [],      // requires reputation_snapshots table
+      change_30d: reputationChange30d,
+      history: reputationHistory,
     },
   });
 });

--- a/src/services/reputationSnapshotService.ts
+++ b/src/services/reputationSnapshotService.ts
@@ -1,0 +1,38 @@
+/**
+ * Reputation Snapshot Service
+ *
+ * Takes a daily snapshot of every agent's reputation_score and writes it into
+ * the `reputation_snapshots` table.  The analytics endpoint reads from this
+ * table to compute:
+ *   - change_30d   – current score minus the score recorded ~30 days ago
+ *   - history      – weekly snapshots for the last 90 days
+ */
+
+import { sql } from 'drizzle-orm';
+import { dbDirect } from '../db/pool.js';
+import { agents, reputationSnapshots } from '../db/schema/index.js';
+
+/**
+ * Snapshot all agents — inserts one row per agent with their current
+ * reputation_score and the current timestamp.
+ *
+ * Designed to run once per day (called from the cron schedule in index.ts).
+ */
+export async function runDailyReputationSnapshot(): Promise<void> {
+  console.log('[ReputationSnapshot] Starting daily reputation snapshot…');
+
+  try {
+    // Insert a snapshot row for every agent in a single bulk INSERT … SELECT
+    const result = await dbDirect.execute(sql`
+      INSERT INTO reputation_snapshots (agent_id, score, recorded_at)
+      SELECT id, reputation_score::numeric, NOW()
+      FROM agents
+    `);
+
+    const count = (result as { rowCount?: number }).rowCount ?? 0;
+    console.log(`[ReputationSnapshot] Snapshot complete — ${count} agents snapshotted.`);
+  } catch (err) {
+    console.error('[ReputationSnapshot] Failed to run daily snapshot:', err);
+    throw err;
+  }
+}


### PR DESCRIPTION
## Summary

Addresses issue #96

### Changes

1. **Migration** ():
   - Creates `reputation_snapshots` table with `id`, `agent_id`, `score`, `recorded_at`
   - Composite index on `(agent_id, recorded_at)`

2. **Drizzle schema** (`src/db/schema/reputation_snapshots.ts`):
   - Typed schema definition matching the migration
   - Exported from `src/db/schema/index.ts`

3. **Snapshot service** (`src/services/reputationSnapshotService.ts`):
   - `runDailyReputationSnapshot()` — bulk-inserts one row per agent via INSERT … SELECT

4. **Daily cron** (`src/index.ts`):
   - Scheduled at 01:00 UTC daily (after the emission cron at 00:00)

5. **Analytics endpoint** (`src/routes/analytics.ts`):
   - `change_30d`: current score minus score recorded ≥30 days ago; `null` if no old snapshot
   - `history`: weekly average scores for the last 90 days; empty array if no snapshots

### Acceptance criteria
- [x] Migration creates `reputation_snapshots` table
- [x] Daily snapshot cron/script exists
- [x] `GET /:agentId/analytics` returns non-null `change_30d` when history exists
- [x] `history` array populated from snapshots
- [x] Null-safe: new agents with no history return `change_30d: null`, `history: []`