### PR TITLE
fix: remove invalid 'cc' suffix from rgba background in StatusStat

### DIFF
--- a/frontend/src/pages/Stats.tsx
+++ b/frontend/src/pages/Stats.tsx
@@ -264,7 +264,7 @@ function StatusStat({ label, value, statusKey }: StatusStatProps) {
   return (
     <div
       className="co-card"
-      style={{ padding: '20px', borderColor: c.border, background: c.bg + 'cc' }}
+      style={{ padding: '20px', borderColor: c.border, background: c.bg }}
     >
       <span className="co-label">{label}</span>
       <p


### PR DESCRIPTION
Removes the `+ 'cc'` hex-opacity trick from `StatusStat`'s background style. The `statusColors.bg` values are already `rgba(...)` strings with built-in opacity, so appending `'cc'` produced invalid CSS like `'rgba(61,90,254,0.1)cc'` which browsers silently ignore.

Addresses issue #117.