### PR TITLE
chore: remove unused Skeleton import in Stats.tsx

### DIFF
--- a/frontend/src/pages/Stats.tsx
+++ b/frontend/src/pages/Stats.tsx
@@ -1,6 +1,5 @@
 import { usePlatformStats } from '@/api/queries';
 import { Users, CheckCircle, ListTodo, Award, Coins, Wallet, CircleDollarSign, TrendingDown, Activity } from 'lucide-react';
-import { Skeleton } from '@/components/ui/skeleton';
 
 /* ────────────────────────────────────────────────────────────
    Cyber-Ocean design tokens (inline so this page is self-contained


### PR DESCRIPTION
Removes the unused `Skeleton` import from `@/components/ui/skeleton` that was left behind after the Cyber-Ocean redesign replaced it with the local `CoSkeleton` component.

Addresses issue #118.