### PR TITLE
fix: define co-pulse keyframe in cyberStyles for CoSkeleton animation

### DIFF
--- a/frontend/src/pages/Stats.tsx
+++ b/frontend/src/pages/Stats.tsx
@@ -166,6 +166,12 @@ const cyberStyles = `
   }
   .co-btn:hover { opacity: 0.88; }
 
+  /* ── skeleton pulse ── */
+  @keyframes co-pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.4; }
+  }
+
   /* ── terminal blink cursor ── */
   @keyframes co-blink {
     0%, 100% { opacity: 1; }
@@ -321,7 +327,7 @@ function CoSkeleton({ height = 120, count = 1 }: { height?: number; count?: numb
           style={{
             height,
             background: 'rgba(13,17,23,0.5)',
-            animation: 'pulse 1.6s ease-in-out infinite',
+            animation: 'co-pulse 1.6s ease-in-out infinite',
           }}
         />
       ))}


### PR DESCRIPTION
## Summary

Addresses issue #119.

Adds a scoped `@keyframes co-pulse` definition to `cyberStyles` in `Stats.tsx` and updates `CoSkeleton` to reference `co-pulse` instead of the implicit Tailwind-global `pulse`.

### Changes
- Added `@keyframes co-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }` to `cyberStyles`
- Changed `CoSkeleton` animation from `'pulse 1.6s ease-in-out infinite'` → `'co-pulse 1.6s ease-in-out infinite'`

This ensures skeleton animations are self-contained and won't break if Tailwind's global `pulse` keyframe is ever tree-shaken or removed.