### PR TITLE
fix: remove dead catch block in ssrfGuard and drop overly broad injection regex

### DIFF
--- a/src/lib/promptGuard.ts
+++ b/src/lib/promptGuard.ts
@@ -62,10 +62,6 @@ const INJECTION_PATTERNS: Array<{ label: string; regex: RegExp }> = [
     regex: /devclaw\/(prompts|projects\/[^/]+\/prompts)\//i,
   },
   {
-    label: 'prompt-override-attempt',
-    regex: /\bnew\s+instructions?\b/i,
-  },
-  {
     label: 'disregard-directive',
     regex: /\bdisregard\s+(the\s+)?(above|previous|prior|all|following)\b/i,
   },

--- a/src/lib/ssrfGuard.ts
+++ b/src/lib/ssrfGuard.ts
@@ -123,22 +123,19 @@ export async function validateOutboundUrl(url: string): Promise<void> {
   }
 
   // DNS resolution — resolve to IPs and check each one
+  // Promise.allSettled never rejects; individual failures are surfaced as 'rejected' results.
   let addresses: string[] = [];
-  try {
-    const [v4Results, v6Results] = await Promise.allSettled([
-      dns.resolve4(hostname),
-      dns.resolve6(hostname),
-    ]);
-    if (v4Results.status === 'fulfilled') addresses.push(...v4Results.value);
-    if (v6Results.status === 'fulfilled') addresses.push(...v6Results.value);
-  } catch {
-    // If DNS resolution completely fails, block as unresolvable to prevent
-    // attackers from exploiting DNS-based SSRF via NXDOMAIN bypass
-    throw new SsrfBlockedError(`hostname "${hostname}" could not be resolved`);
-  }
+  const [v4Results, v6Results] = await Promise.allSettled([
+    dns.resolve4(hostname),
+    dns.resolve6(hostname),
+  ]);
+  if (v4Results.status === 'fulfilled') addresses.push(...v4Results.value);
+  if (v6Results.status === 'fulfilled') addresses.push(...v6Results.value);
 
   if (addresses.length === 0) {
-    throw new SsrfBlockedError(`hostname "${hostname}" resolved to no addresses`);
+    // Both queries failed or returned empty — block as unresolvable to prevent
+    // attackers from exploiting DNS-based SSRF via NXDOMAIN bypass.
+    throw new SsrfBlockedError(`hostname "${hostname}" could not be resolved`);
   }
 
   for (const addr of addresses) {


### PR DESCRIPTION
Addresses issue #110

## Changes

### `src/lib/ssrfGuard.ts`
- Removed dead `try/catch` wrapper around `Promise.allSettled` — `allSettled` never rejects, so the catch was unreachable dead code
- Added clarifying comment on the `addresses.length === 0` path explaining it covers the case where both DNS queries failed or returned empty
- Error message unified to `"could not be resolved"` (was split across two paths)

### `src/lib/promptGuard.ts`
- Removed the `prompt-override-attempt` pattern (`/\bnew\s+instructions?\b/i`) — overly broad, matches common legitimate phrases and generates false-positive injection signals. The `ignore-previous-instructions` pattern already covers the meaningful cases.