### PR TITLE
test: add DB-backed C1 (suspended agent 403) and M1 (assertParticipant strict check) tests

### DIFF
--- a/src/tests/security_audit.test.ts
+++ b/src/tests/security_audit.test.ts
@@ -1,5 +1,5 @@
 /**
- * Security Audit Tests — Issue #101
+ * Security Audit Tests — Issue #101 / #108
  *
  * Tests for:
  *   C1: Suspended agent returns 403
@@ -10,6 +10,9 @@
  *   M1: assertParticipant logic uses strict gig_orders check
  *   M5: secureHeaders middleware sets X-Content-Type-Options: nosniff
  *
+ * C1 and M1 require a live database (DATABASE_URL). The tests skip gracefully
+ * if the DB is not reachable.
+ *
  * Run: npm run test:security
  */
 
@@ -17,8 +20,14 @@ import 'dotenv/config';
 import crypto from 'node:crypto';
 import { Hono } from 'hono';
 import { secureHeaders } from 'hono/secure-headers';
-import { generateAgentId, generateGigId } from '../lib/ids.js';
+import { eq, and, ne, sql } from 'drizzle-orm';
+import bcrypt from 'bcrypt';
+import { generateAgentId, generateGigId, generateGigOrderId } from '../lib/ids.js';
 import { validateWebhookUrl } from '../lib/ssrf.js';
+import { db, initPool } from '../db/pool.js';
+import { agents, gigs, gigOrders } from '../db/schema/index.js';
+import { authMiddleware } from '../auth.js';
+import { orderMessagesRouter } from '../routes/orderMessages.js';
 
 // ---------------------------------------------------------------------------
 // Minimal test runner
@@ -250,6 +259,362 @@ await test('secureHeaders sets X-Frame-Options', async () => {
 });
 
 // ---------------------------------------------------------------------------
+// DB-backed tests: C1 and M1
+//
+// These tests require a live database (DATABASE_URL in .env).
+// If the DB is unavailable, the tests are skipped with a warning.
+// ---------------------------------------------------------------------------
+
+// ── Fixed agent / gig IDs (must be exactly 12 chars per AGENT_ID_LENGTH) ──
+//
+//   agt_secsusp1  = 12 chars  (C1: suspended agent)
+//   agt_m1creato  = 12 chars  (M1: gig creator / agentA)
+//   agt_m1buyerf  = 12 chars  (M1: buyer with active order / agentB)
+//   agt_m1outsr1  = 12 chars  (M1: unrelated outsider / agentC)
+
+const C1_AGENT_ID  = 'agt_secsusp1';
+const C1_API_KEY   = `axe_${C1_AGENT_ID}_${'d'.repeat(64)}`;
+
+const M1_CREATOR_ID = 'agt_m1creato';
+const M1_BUYER_ID   = 'agt_m1buyerf';
+const M1_OUTSIDER_ID = 'agt_m1outsr1';
+
+const M1_CREATOR_KEY  = `axe_${M1_CREATOR_ID}_${'e'.repeat(64)}`;
+const M1_BUYER_KEY    = `axe_${M1_BUYER_ID}_${'f'.repeat(64)}`;
+const M1_OUTSIDER_KEY = `axe_${M1_OUTSIDER_ID}_${'9'.repeat(64)}`;
+
+// IDs allocated here; actual values set during setup
+let m1GigId    = '';
+let m1OrderId  = '';
+
+// ---------------------------------------------------------------------------
+// DB cleanup helpers
+// ---------------------------------------------------------------------------
+
+async function cleanupDbTestData(): Promise<void> {
+  const allAgentIds = [C1_AGENT_ID, M1_CREATOR_ID, M1_BUYER_ID, M1_OUTSIDER_ID];
+
+  // FK order: gig_orders → gigs → agents
+  if (m1OrderId) {
+    await db.execute(sql`DELETE FROM gig_orders WHERE id = ${m1OrderId}`);
+  }
+  if (m1GigId) {
+    await db.execute(sql`DELETE FROM gigs WHERE id = ${m1GigId}`);
+  }
+  await db.execute(sql`
+    DELETE FROM agents
+    WHERE id IN (${C1_AGENT_ID}, ${M1_CREATOR_ID}, ${M1_BUYER_ID}, ${M1_OUTSIDER_ID})
+  `);
+  // Also clean up by twitter handle in case partial setup left orphans
+  await db.execute(sql`
+    DELETE FROM agents
+    WHERE owner_twitter IN (
+      'sec_test_susp', 'sec_m1_creator', 'sec_m1_buyer', 'sec_m1_outsider'
+    )
+  `);
+}
+
+// ---------------------------------------------------------------------------
+// Attempt DB init — skip gracefully if unavailable
+// ---------------------------------------------------------------------------
+
+let dbAvailable = false;
+
+try {
+  await initPool();
+  // Quick connectivity check
+  await db.execute(sql`SELECT 1`);
+  dbAvailable = true;
+} catch (err) {
+  const msg = err instanceof Error ? err.message : String(err);
+  console.warn(`\n⚠️  Database not available (${msg})`);
+  console.warn('   Skipping C1 and M1 (DB-backed tests).\n');
+}
+
+// ---------------------------------------------------------------------------
+// C1: Suspended agent returns 403 on any auth-guarded endpoint
+// ---------------------------------------------------------------------------
+
+if (dbAvailable) {
+  console.log('\n🔒 C1: Suspended agent returns 403');
+
+  // Pre-test cleanup in case a previous run left data behind
+  try {
+    await db.execute(sql`DELETE FROM agents WHERE id = ${C1_AGENT_ID}`);
+    await db.execute(sql`DELETE FROM agents WHERE owner_twitter = 'sec_test_susp'`);
+  } catch { /* ignore */ }
+
+  // Hash the C1 API key with a low cost factor for speed
+  const c1KeyHash = await bcrypt.hash(C1_API_KEY, 4);
+
+  // Insert suspended agent
+  await db.insert(agents).values({
+    id: C1_AGENT_ID,
+    name: 'Suspended Test Agent',
+    ownerTwitter: 'sec_test_susp',
+    status: 'suspended',
+    balancePoints: '0',
+    apiKeyHash: c1KeyHash,
+  });
+
+  // A minimal Hono app with a protected endpoint (mirrors production routes)
+  const c1App = new Hono<{ Variables: { agent: typeof agents.$inferSelect; agentId: string } }>();
+  c1App.get('/protected', authMiddleware, (c) => c.json({ ok: true }));
+
+  await test('suspended agent with valid API key → 403 Forbidden', async () => {
+    const res = await c1App.request('/protected', {
+      headers: { Authorization: `Bearer ${C1_API_KEY}` },
+    });
+
+    assert(res.status === 403, `Expected 403, got ${res.status}`);
+
+    const body = await res.json() as Record<string, unknown>;
+    assert(
+      body.error === 'forbidden',
+      `Expected error="forbidden", got: ${JSON.stringify(body)}`,
+    );
+  });
+
+  await test('suspended agent response body has error: forbidden', async () => {
+    const res = await c1App.request('/protected', {
+      headers: { Authorization: `Bearer ${C1_API_KEY}` },
+    });
+    const body = await res.json() as Record<string, unknown>;
+    assert(
+      typeof body.message === 'string' && body.message.length > 0,
+      `Expected a non-empty message field, got: ${JSON.stringify(body)}`,
+    );
+  });
+
+  await test('non-suspended agent with valid API key passes auth (control)', async () => {
+    // Temporarily create a verified control agent
+    const CTRL_ID  = 'agt_secctrl1';  // 12 chars
+    const CTRL_KEY = `axe_${CTRL_ID}_${'c'.repeat(64)}`;
+    const ctrlHash = await bcrypt.hash(CTRL_KEY, 4);
+
+    try {
+      await db.execute(sql`DELETE FROM agents WHERE id = ${CTRL_ID}`);
+      await db.execute(sql`DELETE FROM agents WHERE owner_twitter = 'sec_test_ctrl'`);
+      await db.insert(agents).values({
+        id: CTRL_ID,
+        name: 'Control Test Agent',
+        ownerTwitter: 'sec_test_ctrl',
+        status: 'verified',
+        balancePoints: '10',
+        apiKeyHash: ctrlHash,
+      });
+
+      const res = await c1App.request('/protected', {
+        headers: { Authorization: `Bearer ${CTRL_KEY}` },
+      });
+
+      assert(res.status === 200, `Expected 200 for verified agent, got ${res.status}`);
+    } finally {
+      await db.execute(sql`DELETE FROM agents WHERE id = ${CTRL_ID}`);
+    }
+  });
+
+  // Cleanup C1 agent
+  await db.execute(sql`DELETE FROM agents WHERE id = ${C1_AGENT_ID}`);
+
+  // ---------------------------------------------------------------------------
+  // M1: assertParticipant strict participant check
+  // ---------------------------------------------------------------------------
+
+  console.log('\n🔒 M1: assertParticipant — strict gig_orders participant check');
+
+  // Pre-test cleanup
+  try {
+    await db.execute(sql`
+      DELETE FROM agents
+      WHERE id IN (${M1_CREATOR_ID}, ${M1_BUYER_ID}, ${M1_OUTSIDER_ID})
+    `);
+    await db.execute(sql`
+      DELETE FROM agents
+      WHERE owner_twitter IN ('sec_m1_creator', 'sec_m1_buyer', 'sec_m1_outsider')
+    `);
+  } catch { /* ignore */ }
+
+  // Hash all M1 keys (bcrypt cost=4 for test speed)
+  const [creatorHash, buyerHash, outsiderHash] = await Promise.all([
+    bcrypt.hash(M1_CREATOR_KEY, 4),
+    bcrypt.hash(M1_BUYER_KEY, 4),
+    bcrypt.hash(M1_OUTSIDER_KEY, 4),
+  ]);
+
+  // Create three agents
+  await db.insert(agents).values([
+    {
+      id: M1_CREATOR_ID,
+      name: 'M1 Creator Agent',
+      ownerTwitter: 'sec_m1_creator',
+      status: 'verified',
+      balancePoints: '100',
+      apiKeyHash: creatorHash,
+    },
+    {
+      id: M1_BUYER_ID,
+      name: 'M1 Buyer Agent',
+      ownerTwitter: 'sec_m1_buyer',
+      status: 'verified',
+      balancePoints: '100',
+      apiKeyHash: buyerHash,
+    },
+    {
+      id: M1_OUTSIDER_ID,
+      name: 'M1 Outsider Agent',
+      ownerTwitter: 'sec_m1_outsider',
+      status: 'verified',
+      balancePoints: '50',
+      apiKeyHash: outsiderHash,
+    },
+  ]);
+
+  // Create gig owned by creator
+  m1GigId = generateGigId();
+  await db.insert(gigs).values({
+    id: m1GigId,
+    creatorAgentId: M1_CREATOR_ID,
+    title: 'M1 Security Test Gig',
+    description: 'Used to test assertParticipant strict check.',
+    category: 'development',
+    pricePoints: '30',
+    status: 'open',
+  });
+
+  // Create active (non-cancelled) order for the buyer
+  m1OrderId = generateGigOrderId();
+  await db.insert(gigOrders).values({
+    id: m1OrderId,
+    gigId: m1GigId,
+    buyerAgentId: M1_BUYER_ID,
+    sellerAgentId: M1_CREATOR_ID,
+    paymentMode: 'points',
+    pricePoints: '30',
+    status: 'accepted',  // active non-cancelled order
+  });
+
+  // Test app — mirrors production mount for /v1/gigs/:gigId/messages
+  const m1App = new Hono();
+  m1App.route('/v1/gigs/:gigId/messages', orderMessagesRouter);
+
+  const m1MessagesUrl = `http://localhost/v1/gigs/${m1GigId}/messages`;
+
+  await test('M1: unrelated agent (agentC) gets 403 on GET messages', async () => {
+    const res = await m1App.fetch(
+      new Request(m1MessagesUrl, {
+        headers: { Authorization: `Bearer ${M1_OUTSIDER_KEY}` },
+      }),
+    );
+    assert(res.status === 403, `Expected 403 for outsider, got ${res.status}`);
+    const body = await res.json() as Record<string, unknown>;
+    assert(
+      body.error === 'forbidden',
+      `Expected error="forbidden", got: ${JSON.stringify(body)}`,
+    );
+  });
+
+  await test('M1: unrelated agent (agentC) gets 403 on POST messages', async () => {
+    const res = await m1App.fetch(
+      new Request(m1MessagesUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${M1_OUTSIDER_KEY}`,
+        },
+        body: JSON.stringify({ content: 'Unauthorized access attempt' }),
+      }),
+    );
+    assert(res.status === 403, `Expected 403 for outsider POST, got ${res.status}`);
+    const body = await res.json() as Record<string, unknown>;
+    assert(
+      body.error === 'forbidden',
+      `Expected error="forbidden", got: ${JSON.stringify(body)}`,
+    );
+  });
+
+  await test('M1: gig creator (agentA) can access GET messages', async () => {
+    const res = await m1App.fetch(
+      new Request(m1MessagesUrl, {
+        headers: { Authorization: `Bearer ${M1_CREATOR_KEY}` },
+      }),
+    );
+    // Read body first so we can include it in the error message without consuming twice
+    const body = await res.json() as Record<string, unknown>;
+    assert(
+      res.status === 200,
+      `Expected 200 for creator, got ${res.status}: ${JSON.stringify(body)}`,
+    );
+    assert(Array.isArray(body.messages), 'Expected messages array in response');
+  });
+
+  await test('M1: buyer with active order (agentB) can access GET messages', async () => {
+    const res = await m1App.fetch(
+      new Request(m1MessagesUrl, {
+        headers: { Authorization: `Bearer ${M1_BUYER_KEY}` },
+      }),
+    );
+    // Read body first so we can include it in the error message without consuming twice
+    const body = await res.json() as Record<string, unknown>;
+    assert(
+      res.status === 200,
+      `Expected 200 for buyer, got ${res.status}: ${JSON.stringify(body)}`,
+    );
+    assert(Array.isArray(body.messages), 'Expected messages array in response');
+  });
+
+  await test('M1: cancelled order does not grant access', async () => {
+    // Create a second gig + cancelled order for the outsider to ensure they are blocked
+    const cancelledGigId = generateGigId();
+    const cancelledOrderId = generateGigOrderId();
+
+    await db.insert(gigs).values({
+      id: cancelledGigId,
+      creatorAgentId: M1_CREATOR_ID,
+      title: 'M1 Cancelled Order Gig',
+      description: 'Tests that a cancelled order does not grant access.',
+      category: 'development',
+      pricePoints: '10',
+      status: 'open',
+    });
+
+    await db.insert(gigOrders).values({
+      id: cancelledOrderId,
+      gigId: cancelledGigId,
+      buyerAgentId: M1_OUTSIDER_ID,  // outsider has a CANCELLED order
+      sellerAgentId: M1_CREATOR_ID,
+      paymentMode: 'points',
+      pricePoints: '10',
+      status: 'cancelled',
+    });
+
+    try {
+      const cancelledUrl = `http://localhost/v1/gigs/${cancelledGigId}/messages`;
+      const res = await m1App.fetch(
+        new Request(cancelledUrl, {
+          headers: { Authorization: `Bearer ${M1_OUTSIDER_KEY}` },
+        }),
+      );
+      assert(
+        res.status === 403,
+        `Expected 403 for outsider with cancelled order, got ${res.status}`,
+      );
+      const body = await res.json() as Record<string, unknown>;
+      assert(
+        body.error === 'forbidden',
+        `Expected error="forbidden", got: ${JSON.stringify(body)}`,
+      );
+    } finally {
+      await db.execute(sql`DELETE FROM gig_orders WHERE id = ${cancelledOrderId}`);
+      await db.execute(sql`DELETE FROM gigs WHERE id = ${cancelledGigId}`);
+    }
+  });
+
+  // Cleanup M1 data
+  await cleanupDbTestData();
+}
+
+// ---------------------------------------------------------------------------
 // Summary
 // ---------------------------------------------------------------------------
 
@@ -258,6 +623,9 @@ const failed = results.filter((r) => !r.passed).length;
 
 console.log(`\n${'─'.repeat(60)}`);
 console.log(`Security audit tests: ${passed} passed, ${failed} failed`);
+if (!dbAvailable) {
+  console.log('  ℹ️  C1 and M1 were skipped (no DATABASE_URL configured)');
+}
 
 if (failed > 0) {
   console.error('\nFailed tests:');


### PR DESCRIPTION
## Summary

Addresses issue #108 — extends `security_audit.test.ts` with DB-backed tests for the two remaining uncovered checklist items from the security audit (#101).

## What's added

### C1: Suspended agent → 403
- Inserts a real agent with `status='suspended'` and a bcrypt-hashed API key into the DB
- Builds a minimal Hono test app with `authMiddleware`
- Asserts `403` with `{ error: 'forbidden' }` for the suspended agent
- Includes a **control test** confirming a verified agent gets `200` through the same middleware
- Cleans up the test agent after the section runs

### M1: assertParticipant strict participant check
- Creates three real agents in the DB: creator (agentA), buyer (agentB), outsider (agentC)
- Creates a gig owned by agentA and an active (`accepted`) order linking agentB as buyer
- Verifies via the real `orderMessagesRouter`:
  - agentC (unrelated) → **403** on both GET and POST messages
  - agentA (creator) → **200** on GET messages
  - agentB (buyer with active order) → **200** on GET messages
  - agentC with a **cancelled** order → **403** (cancelled orders don't grant access)
- Cleans up all test data in FK order after tests complete

## Implementation notes
- DB init is wrapped in a try/catch: if the database is unreachable, C1/M1 are skipped with a warning and the pure-logic tests (C2, H1–H3, M5) still pass
- All 30 tests pass when `DATABASE_URL` is configured: 22 pre-existing + 8 new
- No changes to production code

## Test run
```
npm run test:security
```
All 30 tests ✅