### PR TITLE
feat: apply Cyber-Ocean style to PublicLayout navbar

### DIFF
--- a/frontend/src/layouts/PublicLayout.tsx
+++ b/frontend/src/layouts/PublicLayout.tsx
@@ -4,17 +4,17 @@ import { Menu, X, Moon, Sun } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 
 const navLinks = [
-  { label: 'Explore', href: '/explore', isPage: true },
-  { label: 'Agents', href: '/agents', isPage: true },
-  { label: 'Leaderboard', href: '/leaderboard', isPage: true },
-  { label: 'Stats', href: '/stats', isPage: true },
-  { label: 'API', href: '/api-docs', isPage: true },
+  { label: 'Explore', href: '/explore' },
+  { label: 'Agents', href: '/agents' },
+  { label: 'Leaderboard', href: '/leaderboard' },
+  { label: 'Stats', href: '/stats' },
+  { label: 'API', href: '/api-docs' },
 ];
 
 export default function PublicLayout() {
   const [open, setOpen] = useState(false);
   const [scrolled, setScrolled] = useState(false);
-  const [dark, setDark] = useState(() => document.documentElement.classList.contains('dark'));
+  const [dark, setDark] = useState(true);
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -37,27 +37,31 @@ export default function PublicLayout() {
       {/* Navbar */}
       <nav
         className={`fixed top-0 left-0 right-0 z-50 transition-all duration-300 ${
-          scrolled ? 'bg-background/80 backdrop-blur-xl border-b' : 'bg-background/60 backdrop-blur-sm'
+          scrolled
+            ? 'bg-cyber-bg/80 backdrop-blur-xl border-b border-white/5'
+            : 'bg-transparent'
         }`}
       >
         <div className="container flex items-center justify-between h-16">
+          {/* Logo */}
           <button
             onClick={() => navigate('/')}
-            className="text-lg font-bold tracking-tight text-foreground"
+            className="flex items-center gap-2 font-bold tracking-tight text-white/85"
           >
-            UpMoltWork
+            <img src="/logo.png" alt="UpMoltWork" className="h-8 w-auto" />
+            <span className="text-gradient font-extrabold">UpMoltWork</span>
           </button>
 
           {/* Desktop nav */}
-          <div className="hidden md:flex items-center gap-6">
+          <div className="hidden md:flex items-center gap-7">
             {navLinks.map((l) => (
               <button
                 key={l.href}
                 onClick={() => navigate(l.href)}
                 className={`text-sm transition-colors ${
                   location.pathname.startsWith(l.href)
-                    ? 'text-foreground font-medium'
-                    : 'text-muted-foreground hover:text-foreground'
+                    ? 'text-white/85 font-medium'
+                    : 'text-muted-foreground hover:text-white/85'
                 }`}
               >
                 {l.label}
@@ -65,19 +69,19 @@ export default function PublicLayout() {
             ))}
             <button
               onClick={() => setDark(!dark)}
-              className="p-2 rounded-full text-muted-foreground hover:text-foreground transition-colors"
+              className="p-2 text-muted-foreground hover:text-white/85 transition-colors"
               aria-label="Toggle theme"
             >
               {dark ? <Sun size={16} /> : <Moon size={16} />}
             </button>
           </div>
 
-          {/* Mobile */}
+          {/* Mobile controls */}
           <div className="flex md:hidden items-center gap-2">
             <button onClick={() => setDark(!dark)} className="p-2 text-muted-foreground" aria-label="Toggle theme">
               {dark ? <Sun size={16} /> : <Moon size={16} />}
             </button>
-            <button onClick={() => setOpen(!open)} className="p-2 text-foreground" aria-label="Menu">
+            <button onClick={() => setOpen(!open)} className="p-2 text-white/85" aria-label="Menu">
               {open ? <X size={20} /> : <Menu size={20} />}
             </button>
           </div>
@@ -89,7 +93,7 @@ export default function PublicLayout() {
               initial={{ opacity: 0, height: 0 }}
               animate={{ opacity: 1, height: 'auto' }}
               exit={{ opacity: 0, height: 0 }}
-              className="md:hidden bg-background border-b overflow-hidden"
+              className="md:hidden glass-card border-t border-white/5 overflow-hidden rounded-none"
             >
               <div className="container py-4 flex flex-col gap-3">
                 {navLinks.map((l) => (
@@ -98,8 +102,8 @@ export default function PublicLayout() {
                     onClick={() => navigate(l.href)}
                     className={`text-sm text-left py-2 transition-colors ${
                       location.pathname.startsWith(l.href)
-                        ? 'text-foreground font-medium'
-                        : 'text-muted-foreground hover:text-foreground'
+                        ? 'text-white/85 font-medium'
+                        : 'text-muted-foreground hover:text-white/85'
                     }`}
                   >
                     {l.label}


### PR DESCRIPTION
## Summary

Applies the Cyber-Ocean dark theme to the `PublicLayout.tsx` navbar so inner pages (Explore, Agents, Leaderboard, Stats, API) match the landing page navbar styling.

## Changes

- **Background**: Transparent by default, switches to `bg-cyber-bg/80 backdrop-blur-xl border-b border-white/5` on scroll
- **Logo**: Logo image + `text-gradient font-extrabold` span (matches `Navbar.tsx` post-#131)
- **Nav links**: `text-muted-foreground hover:text-white/85 transition-colors text-sm`
- **Active link**: `text-white/85 font-medium`
- **Mobile menu**: `glass-card border-t border-white/5` (matches `Navbar.tsx`)
- **Dark mode default**: `true` to match the rest of the Cyber-Ocean theme

Addresses issue #132