### PR TITLE
feat: apply Cyber-Ocean styles to DashboardLayout and all dashboard pages

### DIFF
--- a/frontend/src/layouts/DashboardLayout.tsx
+++ b/frontend/src/layouts/DashboardLayout.tsx
@@ -6,8 +6,10 @@ import {
   ArrowLeftRight,
   Gavel,
   Webhook,
-  ChevronLeft,
   Clock,
+  LogOut,
+  Menu,
+  X,
 } from 'lucide-react';
 import { getDashboardToken, clearDashboardToken } from '../components/dashboard/DashboardAccess';
 
@@ -84,42 +86,49 @@ export default function DashboardLayout() {
   };
 
   return (
-    <div className="min-h-screen bg-background text-foreground flex flex-col">
+    <div className="min-h-screen bg-cyber-bg text-foreground flex flex-col">
       {/* Top bar */}
-      <header className="border-b h-14 flex items-center px-4 gap-4 sticky top-0 z-40 bg-background">
+      <header className="bg-cyber-bg/90 backdrop-blur-xl border-b border-white/5 h-14 flex items-center px-4 gap-4 sticky top-0 z-40">
+        {/* Logo */}
         <button
           onClick={() => navigate('/')}
-          className="text-muted-foreground hover:text-foreground transition-colors"
+          className="flex items-center gap-2 font-bold tracking-tight text-white/85 hover:opacity-80 transition-opacity"
           aria-label="Back to home"
         >
-          <ChevronLeft size={20} />
+          <img src="/logo.png" alt="UpMoltWork" className="h-7 w-auto" />
+          <span className="text-gradient text-sm hidden sm:block">UpMoltWork</span>
         </button>
-        <span className="font-semibold text-sm">Dashboard</span>
+
+        {/* Agent ID badge */}
         {agentId && (
-          <span className="text-xs text-muted-foreground font-mono bg-muted px-2 py-1 rounded">
+          <span className="font-mono text-xs bg-card-glass border border-white/10 px-2 py-1 rounded text-accent-blue">
             {agentId}
           </span>
         )}
+
         <div className="ml-auto flex items-center gap-3 text-xs text-muted-foreground">
           {secondsLeft !== null && (
-            <span className={`flex items-center gap-1 ${secondsLeft < 3600 ? 'text-destructive' : ''}`}>
+            <span className={`flex items-center gap-1 ${secondsLeft < 3600 ? 'text-destructive' : 'text-muted-foreground'}`}>
               <Clock size={12} />
               {formatDuration(secondsLeft)}
             </span>
           )}
           <button
             onClick={handleLogout}
-            className="text-muted-foreground hover:text-destructive transition-colors"
+            className="flex items-center gap-1 text-muted-foreground hover:text-destructive transition-colors"
           >
-            Logout
+            <LogOut size={13} />
+            <span className="hidden sm:block">Logout</span>
           </button>
         </div>
+
         {/* Mobile sidebar toggle */}
         <button
-          className="md:hidden ml-2 text-muted-foreground hover:text-foreground"
+          className="md:hidden ml-1 text-muted-foreground hover:text-white/85 transition-colors"
           onClick={() => setSidebarOpen(!sidebarOpen)}
+          aria-label="Toggle sidebar"
         >
-          <LayoutDashboard size={18} />
+          {sidebarOpen ? <X size={18} /> : <Menu size={18} />}
         </button>
       </header>
 
@@ -128,7 +137,7 @@ export default function DashboardLayout() {
         <aside
           className={`${
             sidebarOpen ? 'flex' : 'hidden'
-          } md:flex flex-col w-56 border-r py-4 gap-1 sticky top-14 h-[calc(100vh-3.5rem)] overflow-y-auto`}
+          } md:flex flex-col w-56 bg-cyber-bg border-r border-white/5 py-4 gap-1 sticky top-14 h-[calc(100vh-3.5rem)] overflow-y-auto`}
         >
           {sidebarItems.map(({ label, path, icon: Icon }) => (
             <button
@@ -139,8 +148,8 @@ export default function DashboardLayout() {
               }}
               className={`flex items-center gap-3 px-4 py-2.5 text-sm transition-colors mx-2 rounded-md ${
                 isActive(path)
-                  ? 'bg-primary/10 text-primary font-medium'
-                  : 'text-muted-foreground hover:text-foreground hover:bg-muted'
+                  ? 'bg-accent-purple/10 text-accent-blue font-medium border-l-2 border-accent-blue pl-[14px]'
+                  : 'text-muted-foreground hover:text-white/85 hover:bg-white/5'
               }`}
             >
               <Icon size={16} />

--- a/frontend/src/pages/dashboard/Bids.tsx
+++ b/frontend/src/pages/dashboard/Bids.tsx
@@ -5,7 +5,7 @@ import { getDashboardToken } from '@/components/dashboard/DashboardAccess';
 import StatusBadge from '@/components/shared/StatusBadge';
 import Pagination from '@/components/shared/Pagination';
 import { Skeleton } from '@/components/ui/skeleton';
-import { ExternalLink, DollarSign, Clock } from 'lucide-react';
+import { ExternalLink, Clock } from 'lucide-react';
 
 const LIMIT = 20;
 
@@ -26,11 +26,11 @@ export default function Bids() {
   return (
     <div>
       <div className="flex items-center justify-between mb-4">
-        <h1 className="text-xl font-bold">My Bids</h1>
+        <h1 className="text-xl font-bold text-white/85 tracking-tight">My Bids</h1>
         <select
           value={status}
           onChange={(e) => { setStatus(e.target.value); setOffset(0); }}
-          className="px-3 py-1.5 rounded border bg-background text-sm"
+          className="px-3 py-1.5 rounded border border-white/10 bg-cyber-bg text-sm text-white/85 focus:outline-none focus:border-accent-blue"
         >
           <option value="">All Statuses</option>
           <option value="pending">Pending</option>
@@ -53,25 +53,28 @@ export default function Bids() {
           ) : (
             <div className="space-y-3">
               {data.bids.map(bid => (
-                <div key={bid.id} className="rounded-lg border bg-card p-4">
+                <div key={bid.id} className="glass-card p-4">
                   <div className="flex items-start justify-between gap-3 mb-2">
                     <div className="flex-1 min-w-0">
                       <div className="flex items-center gap-2 mb-1">
                         <StatusBadge status={bid.status} />
-                        <Link to={`/explore/${bid.task_id}`} className="text-sm font-medium hover:text-primary transition-colors flex items-center gap-1">
+                        <Link
+                          to={`/explore/${bid.task_id}`}
+                          className="text-sm font-medium text-white/85 hover:text-accent-blue transition-colors flex items-center gap-1"
+                        >
                           {bid.task.title ?? bid.task_id}
                           <ExternalLink size={12} />
                         </Link>
                       </div>
                       {bid.task.category && (
-                        <span className="text-xs text-muted-foreground capitalize bg-muted px-2 py-0.5 rounded">
+                        <span className="text-xs text-muted-foreground capitalize bg-white/5 border border-white/10 px-2 py-0.5 rounded">
                           {bid.task.category}
                         </span>
                       )}
                     </div>
                     <div className="text-right text-sm">
                       {bid.price_points != null && (
-                        <span className="flex items-center gap-1 text-muted-foreground justify-end">
+                        <span className="flex items-center gap-1 font-mono text-accent-blue text-sm justify-end">
                           {bid.price_points} 🐚
                         </span>
                       )}
@@ -84,7 +87,7 @@ export default function Bids() {
                   </div>
                   <p className="text-sm text-muted-foreground line-clamp-2">{bid.proposed_approach}</p>
                   {bid.created_at && (
-                    <p className="text-xs text-muted-foreground mt-2">
+                    <p className="text-xs text-muted-foreground font-mono mt-2">
                       {new Date(bid.created_at).toLocaleString()}
                     </p>
                   )}

--- a/frontend/src/pages/dashboard/MyTasks.tsx
+++ b/frontend/src/pages/dashboard/MyTasks.tsx
@@ -26,14 +26,14 @@ function TaskPrice({ task }: { task: { payment_mode?: string | null; price_point
     const label = isMainnet ? `$${price_usdc} USDC` : `$${price_usdc} USDC${isSepolia ? ' (testnet)' : ''}`;
     return (
       <span className="flex items-center gap-1">
-        <span className="text-blue-600 dark:text-blue-400 font-medium">{label}</span>
+        <span className="font-mono text-accent-blue text-sm font-medium">{label}</span>
         {explorerUrl && (
           <a
             href={explorerUrl}
             target="_blank"
             rel="noopener noreferrer"
             onClick={(e) => e.stopPropagation()}
-            className="text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-200"
+            className="text-accent-blue hover:text-white/85 transition-colors"
             title={isMainnet ? 'View on BaseScan' : 'View on BaseScan Sepolia'}
           >
             <ExternalLink size={12} />
@@ -43,7 +43,7 @@ function TaskPrice({ task }: { task: { payment_mode?: string | null; price_point
     );
   }
   if (price_points != null) {
-    return <span className="flex items-center gap-1">{price_points} 🐚</span>;
+    return <span className="flex items-center gap-1 font-mono text-accent-blue text-sm">{price_points} 🐚</span>;
   }
   return <span className="text-muted-foreground">—</span>;
 }
@@ -69,18 +69,18 @@ export default function MyTasks() {
 
   return (
     <div>
-      <h1 className="text-xl font-bold mb-4">My Tasks</h1>
+      <h1 className="text-xl font-bold text-white/85 tracking-tight mb-4">My Tasks</h1>
 
       {/* Tabs */}
-      <div className="flex gap-1 mb-5 border-b">
+      <div className="flex gap-1 mb-5 border-b border-white/5">
         {tabs.map(t => (
           <button
             key={t.value}
             onClick={() => { setRole(t.value); setOffset(0); }}
             className={`px-4 py-2 text-sm font-medium transition-colors border-b-2 -mb-px ${
               role === t.value
-                ? 'border-primary text-foreground'
-                : 'border-transparent text-muted-foreground hover:text-foreground'
+                ? 'border-accent-blue text-accent-blue'
+                : 'border-transparent text-muted-foreground hover:text-white/85'
             }`}
           >
             {t.label}
@@ -99,32 +99,32 @@ export default function MyTasks() {
           {data.tasks.length === 0 ? (
             <p className="text-muted-foreground text-sm py-8 text-center">No tasks found.</p>
           ) : (
-            <div className="border rounded-lg overflow-hidden">
+            <div className="glass-card overflow-hidden">
               <table className="w-full text-sm">
-                <thead className="bg-muted">
-                  <tr>
-                    <th className="text-left p-3 font-medium text-muted-foreground">Task</th>
-                    <th className="text-left p-3 font-medium text-muted-foreground hidden sm:table-cell">Category</th>
-                    <th className="text-left p-3 font-medium text-muted-foreground">Status</th>
-                    <th className="text-left p-3 font-medium text-muted-foreground hidden md:table-cell">Price</th>
-                    <th className="text-left p-3 font-medium text-muted-foreground hidden lg:table-cell">Date</th>
+                <thead>
+                  <tr className="border-b border-white/5">
+                    <th className="text-left p-3 text-muted-foreground text-xs uppercase tracking-wider font-medium">Task</th>
+                    <th className="text-left p-3 text-muted-foreground text-xs uppercase tracking-wider font-medium hidden sm:table-cell">Category</th>
+                    <th className="text-left p-3 text-muted-foreground text-xs uppercase tracking-wider font-medium">Status</th>
+                    <th className="text-left p-3 text-muted-foreground text-xs uppercase tracking-wider font-medium hidden md:table-cell">Price</th>
+                    <th className="text-left p-3 text-muted-foreground text-xs uppercase tracking-wider font-medium hidden lg:table-cell">Date</th>
                     <th className="p-3"></th>
                   </tr>
                 </thead>
-                <tbody className="divide-y">
+                <tbody className="divide-y divide-white/5">
                   {data.tasks.map(t => (
-                    <tr key={t.id} className="hover:bg-muted/50 transition-colors">
-                      <td className="p-3 font-medium max-w-xs truncate">{t.title}</td>
+                    <tr key={t.id} className="hover:bg-white/3 transition-colors">
+                      <td className="p-3 font-medium text-white/85 max-w-xs truncate">{t.title}</td>
                       <td className="p-3 text-muted-foreground capitalize hidden sm:table-cell">{t.category}</td>
                       <td className="p-3"><StatusBadge status={t.status} /></td>
-                      <td className="p-3 text-muted-foreground hidden md:table-cell">
+                      <td className="p-3 hidden md:table-cell">
                         <TaskPrice task={t} />
                       </td>
-                      <td className="p-3 text-muted-foreground hidden lg:table-cell">
+                      <td className="p-3 text-muted-foreground hidden lg:table-cell font-mono text-xs">
                         {t.created_at ? new Date(t.created_at).toLocaleDateString() : '—'}
                       </td>
                       <td className="p-3">
-                        <Link to={`/explore/${t.id}`} className="text-primary hover:text-primary/80">
+                        <Link to={`/explore/${t.id}`} className="text-accent-blue hover:text-white/85 transition-colors">
                           <ExternalLink size={14} />
                         </Link>
                       </td>

--- a/frontend/src/pages/dashboard/Overview.tsx
+++ b/frontend/src/pages/dashboard/Overview.tsx
@@ -11,12 +11,14 @@ import type { Task } from '@/api/queries';
 
 function TransactionRow({ tx }: { tx: Transaction }) {
   return (
-    <div className="flex items-center gap-3 py-2.5 border-b last:border-0 text-sm">
-      <span className="bg-muted px-2 py-0.5 rounded text-xs capitalize">{tx.type.replace(/_/g, ' ')}</span>
-      <span className={`font-medium ${tx.to_agent_id ? 'text-green-600 dark:text-green-400' : ''}`}>
+    <div className="flex items-center gap-3 py-2.5 border-b border-white/5 last:border-0 text-sm">
+      <span className="bg-white/5 border border-white/10 px-2 py-0.5 rounded text-xs capitalize text-muted-foreground">
+        {tx.type.replace(/_/g, ' ')}
+      </span>
+      <span className={`font-mono font-medium text-sm ${tx.to_agent_id ? 'text-green-400' : 'text-muted-foreground'}`}>
         {tx.amount > 0 ? '+' : ''}{tx.amount} {tx.currency}
       </span>
-      {tx.memo && <span className="text-muted-foreground truncate">{tx.memo}</span>}
+      {tx.memo && <span className="text-muted-foreground truncate text-xs">{tx.memo}</span>}
       {tx.created_at && (
         <span className="ml-auto text-xs text-muted-foreground">{new Date(tx.created_at).toLocaleDateString()}</span>
       )}
@@ -53,44 +55,44 @@ export default function Overview() {
   return (
     <div className="space-y-6">
       <div className="flex items-center gap-3">
-        <h1 className="text-xl font-bold">{agent.name}</h1>
+        <h1 className="text-xl font-bold text-white/85 tracking-tight">{agent.name}</h1>
         <StatusBadge status={agent.status} />
         <ReputationBadge score={agent.reputation_score} className="ml-2" />
       </div>
 
       {/* Balance + stats */}
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-        <div className="rounded-lg border bg-card p-4">
-          <div className="flex items-center gap-2 text-muted-foreground text-sm mb-2">
-            <Coins size={15} /> Shells 🐚 Balance
+        <div className="glass-card p-4">
+          <div className="flex items-center gap-2 text-muted-foreground text-xs uppercase tracking-wider mb-3">
+            <Coins size={14} /> Shells 🐚 Balance
           </div>
-          <p className="text-2xl font-bold">{agent.balance_points.toFixed(2)}</p>
+          <p className="text-2xl font-bold text-white/85">{agent.balance_points.toFixed(2)}</p>
         </div>
-        <div className="rounded-lg border bg-card p-4">
-          <div className="flex items-center gap-2 text-muted-foreground text-sm mb-2">
-            <Coins size={15} /> USDC Balance
+        <div className="glass-card p-4">
+          <div className="flex items-center gap-2 text-muted-foreground text-xs uppercase tracking-wider mb-3">
+            <Coins size={14} /> USDC Balance
           </div>
-          <p className="text-2xl font-bold">{agent.balance_usdc.toFixed(2)}</p>
+          <p className="text-2xl font-bold text-white/85">{agent.balance_usdc.toFixed(2)}</p>
         </div>
-        <div className="rounded-lg border bg-card p-4">
-          <div className="flex items-center gap-2 text-muted-foreground text-sm mb-2">
-            <CheckCircle size={15} /> Tasks Completed
+        <div className="glass-card p-4">
+          <div className="flex items-center gap-2 text-muted-foreground text-xs uppercase tracking-wider mb-3">
+            <CheckCircle size={14} /> Tasks Completed
           </div>
-          <p className="text-2xl font-bold">{agent.tasks_completed}</p>
+          <p className="text-2xl font-bold text-white/85">{agent.tasks_completed}</p>
         </div>
-        <div className="rounded-lg border bg-card p-4">
-          <div className="flex items-center gap-2 text-muted-foreground text-sm mb-2">
-            <TrendingUp size={15} /> Success Rate
+        <div className="glass-card p-4">
+          <div className="flex items-center gap-2 text-muted-foreground text-xs uppercase tracking-wider mb-3">
+            <TrendingUp size={14} /> Success Rate
           </div>
-          <p className="text-2xl font-bold">{parseFloat(String(agent.success_rate ?? 0)).toFixed(0)}%</p>
+          <p className="text-2xl font-bold text-white/85">{parseFloat(String(agent.success_rate ?? 0)).toFixed(0)}%</p>
         </div>
       </div>
 
       <div className="grid gap-6 lg:grid-cols-2">
         {/* Recent tasks */}
-        <div className="rounded-lg border bg-card p-5">
-          <h2 className="font-semibold mb-3 flex items-center gap-2">
-            <ListTodo size={15} /> Recent Tasks
+        <div className="glass-card p-5">
+          <h2 className="font-bold text-white/85 tracking-tight mb-4 flex items-center gap-2">
+            <ListTodo size={15} className="text-accent-blue" /> Recent Tasks
           </h2>
           {recent_tasks.length === 0 ? (
             <p className="text-sm text-muted-foreground">No tasks yet.</p>
@@ -102,9 +104,9 @@ export default function Overview() {
         </div>
 
         {/* Recent transactions */}
-        <div className="rounded-lg border bg-card p-5">
-          <h2 className="font-semibold mb-3 flex items-center gap-2">
-            <Coins size={15} /> Recent Transactions
+        <div className="glass-card p-5">
+          <h2 className="font-bold text-white/85 tracking-tight mb-4 flex items-center gap-2">
+            <Coins size={15} className="text-accent-blue" /> Recent Transactions
           </h2>
           {recent_transactions.length === 0 ? (
             <p className="text-sm text-muted-foreground">No transactions yet.</p>

--- a/frontend/src/pages/dashboard/Transactions.tsx
+++ b/frontend/src/pages/dashboard/Transactions.tsx
@@ -27,11 +27,11 @@ export default function Transactions() {
   return (
     <div>
       <div className="flex items-center justify-between mb-4">
-        <h1 className="text-xl font-bold">Transactions</h1>
+        <h1 className="text-xl font-bold text-white/85 tracking-tight">Transactions</h1>
         <select
           value={type}
           onChange={(e) => { setType(e.target.value); setOffset(0); }}
-          className="px-3 py-1.5 rounded border bg-background text-sm"
+          className="px-3 py-1.5 rounded border border-white/10 bg-cyber-bg text-sm text-white/85 focus:outline-none focus:border-accent-blue"
         >
           {TX_TYPES.map(t => (
             <option key={t} value={t}>{t === '' ? 'All Types' : t.replace(/_/g, ' ')}</option>
@@ -50,42 +50,42 @@ export default function Transactions() {
           {data.transactions.length === 0 ? (
             <p className="text-muted-foreground text-sm py-8 text-center">No transactions found.</p>
           ) : (
-            <div className="border rounded-lg overflow-hidden">
+            <div className="glass-card overflow-hidden">
               <table className="w-full text-sm">
-                <thead className="bg-muted">
-                  <tr>
-                    <th className="text-left p-3 font-medium text-muted-foreground">Date</th>
-                    <th className="text-left p-3 font-medium text-muted-foreground">Type</th>
-                    <th className="text-left p-3 font-medium text-muted-foreground">Amount</th>
-                    <th className="text-left p-3 font-medium text-muted-foreground hidden sm:table-cell">From / To</th>
-                    <th className="text-left p-3 font-medium text-muted-foreground hidden md:table-cell">Memo</th>
+                <thead>
+                  <tr className="border-b border-white/5">
+                    <th className="text-left p-3 text-muted-foreground text-xs uppercase tracking-wider font-medium">Date</th>
+                    <th className="text-left p-3 text-muted-foreground text-xs uppercase tracking-wider font-medium">Type</th>
+                    <th className="text-left p-3 text-muted-foreground text-xs uppercase tracking-wider font-medium">Amount</th>
+                    <th className="text-left p-3 text-muted-foreground text-xs uppercase tracking-wider font-medium hidden sm:table-cell">From / To</th>
+                    <th className="text-left p-3 text-muted-foreground text-xs uppercase tracking-wider font-medium hidden md:table-cell">Memo</th>
                   </tr>
                 </thead>
-                <tbody className="divide-y">
+                <tbody className="divide-y divide-white/5">
                   {data.transactions.map(tx => {
                     const isIncoming = tx.to_agent_id === agentId;
                     return (
-                      <tr key={tx.id} className="hover:bg-muted/50 transition-colors">
-                        <td className="p-3 text-muted-foreground">
+                      <tr key={tx.id} className="hover:bg-white/3 transition-colors">
+                        <td className="p-3 text-muted-foreground font-mono text-xs">
                           {tx.created_at ? new Date(tx.created_at).toLocaleDateString() : '—'}
                         </td>
                         <td className="p-3">
-                          <span className="bg-muted px-2 py-0.5 rounded text-xs capitalize">
+                          <span className="bg-white/5 border border-white/10 px-2 py-0.5 rounded text-xs capitalize text-muted-foreground">
                             {tx.type.replace(/_/g, ' ')}
                           </span>
                         </td>
                         <td className="p-3">
-                          <span className={`flex items-center gap-1 font-medium ${isIncoming ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
+                          <span className={`flex items-center gap-1 font-mono font-medium text-sm ${isIncoming ? 'text-green-400' : 'text-red-400'}`}>
                             {isIncoming ? <ArrowDownLeft size={13} /> : <ArrowUpRight size={13} />}
                             {isIncoming ? '+' : '-'}{tx.amount} {tx.currency}
                           </span>
                         </td>
-                        <td className="p-3 text-muted-foreground text-xs hidden sm:table-cell">
+                        <td className="p-3 text-muted-foreground font-mono text-xs hidden sm:table-cell">
                           {isIncoming
                             ? `from ${tx.from_agent_id ?? 'system'}`
                             : `to ${tx.to_agent_id}`}
                         </td>
-                        <td className="p-3 text-muted-foreground hidden md:table-cell max-w-xs truncate">
+                        <td className="p-3 text-muted-foreground hidden md:table-cell max-w-xs truncate text-xs">
                           {tx.memo ?? tx.task_id ?? '—'}
                         </td>
                       </tr>

--- a/frontend/src/pages/dashboard/WebhookEvents.tsx
+++ b/frontend/src/pages/dashboard/WebhookEvents.tsx
@@ -12,39 +12,39 @@ function PayloadRow({ webhook }: { webhook: { id: string; event: string; payload
   const [open, setOpen] = useState(false);
 
   return (
-    <div className="border rounded-lg overflow-hidden">
+    <div className="glass-card overflow-hidden">
       <button
-        className="w-full flex items-center gap-3 p-3 hover:bg-muted/50 transition-colors text-left"
+        className="w-full flex items-center gap-3 p-3 hover:bg-white/3 transition-colors text-left"
         onClick={() => setOpen(!open)}
       >
         <span className="text-muted-foreground">
           {open ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
         </span>
-        <span className="text-sm font-mono font-medium">{webhook.event}</span>
+        <span className="text-sm font-mono font-medium text-accent-blue">{webhook.event}</span>
         {webhook.status_code && (
           <span className={`text-xs px-1.5 py-0.5 rounded font-mono ${
             webhook.status_code >= 200 && webhook.status_code < 300
-              ? 'bg-green-500/15 text-green-600 dark:text-green-400'
-              : 'bg-red-500/15 text-red-600 dark:text-red-400'
+              ? 'bg-green-500/15 text-green-400'
+              : 'bg-red-500/15 text-red-400'
           }`}>
             {webhook.status_code}
           </span>
         )}
         <span className="flex items-center gap-1 text-xs ml-auto">
           {webhook.delivered
-            ? <><CheckCircle2 size={12} className="text-green-500" /> Delivered</>
-            : <><XCircle size={12} className="text-muted-foreground" /> Pending</>
+            ? <><CheckCircle2 size={12} className="text-green-400" /> <span className="text-green-400">Delivered</span></>
+            : <><XCircle size={12} className="text-muted-foreground" /> <span className="text-muted-foreground">Pending</span></>
           }
         </span>
         {webhook.created_at && (
-          <span className="text-xs text-muted-foreground hidden sm:block">
+          <span className="text-xs text-muted-foreground font-mono hidden sm:block">
             {new Date(webhook.created_at).toLocaleString()}
           </span>
         )}
       </button>
       {open && (
-        <div className="border-t bg-muted/30 p-3">
-          <pre className="text-xs font-mono overflow-x-auto whitespace-pre-wrap break-all">
+        <div className="border-t border-white/5 bg-white/3 p-3">
+          <pre className="text-xs font-mono overflow-x-auto whitespace-pre-wrap break-all text-white/70">
             {JSON.stringify(webhook.payload, null, 2)}
           </pre>
         </div>
@@ -64,7 +64,7 @@ export default function WebhookEvents() {
 
   return (
     <div>
-      <h1 className="text-xl font-bold mb-4">Webhook Events</h1>
+      <h1 className="text-xl font-bold text-white/85 tracking-tight mb-4">Webhook Events</h1>
 
       {isLoading && (
         <div className="space-y-2">


### PR DESCRIPTION
## Summary

Applies the Cyber-Ocean design system to the dashboard layout and all dashboard pages.

### DashboardLayout.tsx
- Header: `bg-cyber-bg/90 backdrop-blur-xl border-b border-white/5` glassmorphism
- Logo: `/logo.png` + gradient "UpMoltWork" text linking to `/`
- Agent ID badge: `font-mono text-xs bg-card-glass border border-white/10 px-2 py-1 rounded text-accent-blue`
- Logout: `text-muted-foreground hover:text-destructive` with LogOut icon
- Sidebar: `bg-cyber-bg border-r border-white/5`
- Active nav: `bg-accent-purple/10 text-accent-blue font-medium border-l-2 border-accent-blue`
- Inactive nav: `text-muted-foreground hover:text-white/85 hover:bg-white/5`

### Dashboard pages (Overview, MyTasks, Transactions, Bids, WebhookEvents)
- Cards: `glass-card` glassmorphism class
- IDs, amounts, addresses: `font-mono text-accent-blue text-sm`
- Table headers: `text-muted-foreground text-xs uppercase tracking-wider`
- Section headings: `font-bold text-white/85 tracking-tight`
- Table rows: `divide-white/5` borders, `hover:bg-white/3` hover
- Type badges: `bg-white/5 border border-white/10` subtle chips
- Select dropdowns: `bg-cyber-bg border-white/10 focus:border-accent-blue`
- Positive amounts: green-400, negative: red-400

All data fetching, routing, and auth logic is unchanged.

Addresses issue #133